### PR TITLE
Add geo objects

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -126,10 +126,15 @@ Reusable React UI components.
     - Other: `groupobject.tsx`
 
 - **`sidebar/`**: Left sidebar UI
-    - `primary.tsx` - Main sidebar component
-    - `defaults.tsx` - Defaults section sidebar (where default stroke width and stroke type can be applied)
+    - `primary.tsx` - Main sidebar component; applies the current element defaults (`linewidth`, `strokeType`, `stroke`) to newly created components
+    - `elementProperties.tsx` - Unified element-properties toolbar shown for the current selection. The `SETS` map declares which property sections (`fill`, `stroke`, `strokeWidth`, `strokeType`, `opacity`, `textColor`, `textSize`, `textFont`) render per element kind (`SHAPE`, `ARROW`, `PENCIL`, `TEXT`, `RECT_WITH_TEXT`, `GROUP`); `resolveSetKey()` picks the active set. This replaced the old standalone `defaults.tsx`
+    - `shapesToolbar.tsx` - Shape picker toolbar (+ undo/redo); flattens the shapes drawer into a flat list for desktop
+    - `menuDrawer.tsx` - Hamburger menu drawer (nav links, modal triggers)
     - `shareLinkPopup.tsx` - Share functionality popup
     - `userDetailsPopup.tsx` - User information popup
+    - `sidebar.css` - Sidebar styles
+
+  **Element defaults vs. selected-shape edits:** `src/utils/applyProperty.ts` (`createApplyProperty`) is the single mutation path behind `elementProperties.tsx`. Every property change (1) updates the matching default via `useElementDefaults` setters, then (2) if a shape is selected, applies the same change to that shape. So editing a property with nothing selected just sets the default; editing with a shape selected sets both. Defaults store `null` for `strokeType: 'solid'` (matching what `primary.tsx` feeds new shapes); DB rows store the literal `'solid'`/`'dashed'`/`'dotted'`.
 
 - **`common/`**: Shared utility components
     - `button.tsx` - Base button component
@@ -234,14 +239,14 @@ Global stylesheets.
 
 ## React Context
 
-The **BoardContext** (created in `src/views/Board/board.js`) provides:
+The **BoardContext** (created in `src/views/Board/board.tsx`) provides:
 
 - Component store state
 - Selected component state
 - Two.js instance
 - Pencil mode state (from `useDrawingModes` hook)
 - Toolbar visibility (from `useMobileToolbarPanels` hook)
-- Pencil/stroke defaults (from `usePencilDefaults` hook)
+- Element defaults — stroke/fill/text (from `useElementDefaults` hook)
 - Undo/history functions — `recordToHistoryLog`, `undoLastAction` (from `useComponentHistory` hook)
 - GraphQL mutation functions
 - `boardId`, `isPersisted`, `persistBoard`, `backgroundBoardId` (canvas-first UX)
@@ -249,13 +254,13 @@ The **BoardContext** (created in `src/views/Board/board.js`) provides:
 
 Child components access this context via `useContext(BoardContext)`.
 
-### Hook composition in board.js
+### Hook composition in board.tsx
 
-`board.js` composes several custom hooks in this order (order matters — each may depend on the previous):
+`board.tsx` composes several custom hooks in this order (order matters — each may depend on the previous):
 
 1. `useDrawingModes()` — draw mode state and setters
-2. `useMobileToolbarPanels({ isPencilMode, isMobile, selectedComponent })` — panel visibility
-3. `usePencilDefaults({ toggleToolbar, setSelectedComponent })` — defaults and their setters
+2. `useMobileToolbarPanels({ isMobile, selectedComponent })` — panel visibility
+3. `useElementDefaults()` — element defaults (stroke/fill/text) and their setters
 4. `useLocalDraftPersistence({ ..., onStorageLimitRef })` — draft persistence + quota modal
 5. `useComponentHistory({ ... })` — undo stack
 

--- a/.claude/context/geo-objects-plan.md
+++ b/.claude/context/geo-objects-plan.md
@@ -1,0 +1,172 @@
+# Geo Objects (point / area / route) — Implementation Plan
+
+Adds a new **geo** category of element to craftbase, surfaced only when a
+consumer (craftmaps) opts in via a Board prop. Three types:
+
+- **point** — a circle ring with an embedded SVG icon (default "pin"), counter-scaled so it stays legible when zoomed out.
+- **area** — a closed `Two.Path` (polygon). Editable property: **stroke**. Fill = stroke color at 0.7 opacity (light shade).
+- **route** — an open `Two.Path` (polyline, `closed:false`). Editable property: **stroke** (+ width/type).
+
+No text inside any geo object (ignore the multiline-text layer entirely).
+
+## Decisions locked in
+
+1. **Storage:** Reuse `components_component` + a `geoObjectType` catalog table. No parallel `geoObject` table. Geometry/vertices live in the existing `metadata` jsonb (same pattern as `pencil`).
+2. **Toolbar:** When the consumer opts in, geo tools appear **alongside** the existing shape tools (additive, not a replacement).
+3. **Draw interaction:** Multi-click to drop vertices with a live rubber-band preview; finish with Esc/Enter/double-click (area needs ≥3, route needs ≥2). Point is a single click-to-place.
+
+---
+
+## Part A — DB plan (for the craftbase-hasura-clone agent)
+
+### A1. `components_component` — add a discriminator column
+
+- Add `objectClass text NOT NULL DEFAULT 'shape'` (values: `'shape'` | `'geo'`).
+- Existing rows are unaffected (default `'shape'`).
+- Track the column in Hasura; ensure it's in the `_insert_input`, `_set_input`, and selectable for the `user` role.
+
+### A2. New catalog table `components_geoObjectType`
+
+Mirror `components_componentType`. Suggested columns:
+
+| column         | type    | notes                                              |
+| -------------- | ------- | -------------------------------------------------- |
+| `label`        | text PK | `'point'` \| `'area'` \| `'route'`                 |
+| `defaultStroke`| text    | default stroke color per type                      |
+| `linewidth`    | int     | default line width                                 |
+| `logo`         | text    | toolbar/icon hint (optional)                       |
+| `metadata`     | jsonb   | type-specific defaults, e.g. point `{ resist: 0.9, ringRadius: 22, svgIcon: '<default pin>' }` |
+
+Seed three rows: `point`, `area`, `route`. Track the table; grant `select` to `user`.
+
+### A3. Geometry shape stored in `components_component.metadata`
+
+No new columns needed beyond `objectClass`. Reuse:
+
+- `x`, `y` → group origin (first vertex / centroid).
+- `stroke`, `linewidth`, `strokeType` → existing.
+- `fill` → **not stored for geo.** Area fill is always derived client-side from `stroke` at 0.7 opacity (`strokeToAreaFill`). Leave the `fill` column null/untouched for geo rows.
+- `metadata` jsonb:
+    - **point:** `{ svgIcon: string, resist: number, ringRadius: number }`
+    - **area:** `{ vertices: [{x,y}, ...] }` (relative to group origin, closed)
+    - **route:** `{ vertices: [{x,y}, ...] }` (relative to group origin, open)
+
+### A4. Query/subscription/codegen changes
+
+- Add `objectClass` to the select sets of: `GET_COMPONENTS_FOR_BOARD_QUERY`, `GET_COMPONENT_INFO_QUERY`, `GET_COMPONENTS_FOR_BOARD_SUBSCRIPTION`, `GET_COMPONENT_INFO_SUBSCRIPTION`. (`metadata` is already selected — that carries the vertices.)
+- Add a new `GET_GEO_OBJECT_TYPES` query + subscription mirroring `GET_COMPONENT_TYPES` against `components_geoObjectType`.
+- **No new insert/update/delete mutations.** `insert_components_component_one`, `update_components_component_by_pk`, and the delete mutations all carry geo rows for free once `objectClass` is tracked.
+- Run `yarn codegen` after the metadata + table land so `src/schema/generated.ts` picks up `objectClass` and the new catalog type.
+
+---
+
+## Part B — Client plan (craftbase `src/`)
+
+The renderer needs **zero changes**: `handleSetComponentsToRender` maps
+`componentType` → `./components/elements/{type}.tsx` via the
+`import.meta.glob('./components/elements/*.tsx')` (`newCanvas.tsx:50`). Dropping
+in `point.tsx`/`area.tsx`/`route.tsx` registers them automatically. Insert/
+update/delete, the board subscription, undo-history, clipboard, and the
+localStorage draft all flow through `componentStore` and work unchanged.
+
+### B1. Constants — `src/constants/misc.ts`
+
+- Extend `componentTypes` with `point`, `area`, `route`.
+- Add a `geoObjectTypes = { point, area, route }` set and a helper `isGeoType(t)`.
+- Add `GEO_DRAW_MODE_KEY` (multi-click area/route) and reuse `PENDING_SHAPE_TYPE_KEY` / `LAST_ADDED_ELEMENT_ID_KEY` for point placement.
+- Add `DEFAULT_PIN_SVG` string and `DEFAULT_GEO_RESIST = 0.9`.
+
+### B2. Generic counter-scale util — `src/utils/counterScale.ts` (new)
+
+```ts
+// pin/point stays legible when the world zooms out.
+// resist=0 → fully fixed on screen; resist=1 → scales with world.
+export function computeCounterScale(zuiScale: number, resist = 0.9): number {
+    return 1 / Math.pow(zuiScale, resist)
+}
+```
+
+### B3. Color helper — `src/utils/misc.ts`
+
+Add `strokeToAreaFill(stroke: string): string` → returns the stroke color as
+rgba with alpha `0.7` (handle `#rgb`/`#rrggbb`/`rgb()/rgba()`; fall back to the
+input). Used so an area's fill is a light shade of its stroke, and so editing
+stroke re-derives fill.
+
+### B4. Factories — `src/factory/{point,area,route}.ts` (new)
+
+Model on `circle.ts` / `pencil.ts` (extend `Main`, return `{ group, <shape> }`).
+
+- **point.ts:** `two.makeGroup()` containing (1) a ring `Two.Circle(0,0,ringRadius)` with `fill='transparent'`, `stroke=props.stroke`, and (2) the SVG icon embedded via `two.interpret(svgNode)` (parse `metadata.svgIcon || DEFAULT_PIN_SVG`), centered, recolored to stroke. Group translation = `x,y`.
+- **area.ts:** `new Two.Path(anchors, true, false)` from `metadata.vertices`; `stroke=props.stroke`, `linewidth`, `fill=strokeToAreaFill(stroke)`. Group at `x,y`.
+- **route.ts:** `new Two.Path(anchors, false, false)`; `noFill()`, `stroke`, `linewidth`, `cap='round'`, `join='round'`. Group at `x,y`.
+
+### B5. Element components — `src/components/elements/{point,area,route}.tsx` (new)
+
+Model on `circle.tsx` (mount factory in `useEffect([],[])`, set
+`group.elementData`, handle `parentGroup` for group membership, wire
+`.dragger-picker` + `data-component-id` + `data-linewidth`, `two.remove(group)`
+cleanup, pointer-events effect on draw modes). No `applyShapeText` calls.
+
+- **point.tsx extra:** subscribe to the `zoomChanged` CustomEvent (`{ detail: { scale } }`, dispatched at `newCanvas.tsx:1886` & `:2217`) and on each event set `group.scale = computeCounterScale(scale, resist)` then `two.update()`. Read initial scale from the camera once on mount. (Uses a window event listener, so no stale-closure issue — it re-reads each fire.)
+- **area.tsx extra:** the stroke effect must update **both** `path.stroke` and `path.fill = strokeToAreaFill(stroke)`.
+- Update effects react to `props.stroke`, `props.linewidth`, `props.strokeType`, and `props.metadata` (vertex changes from undo) — rebuild vertices from `metadata.vertices` (frozen-props rule: store-driven updates mutate Two.js directly).
+
+### B6. Toolbar — opt-in geo tools
+
+- **BoardProps** (`src/types/board.ts`): add `geoObjectsEnabled?: boolean` (default-free, no-op when omitted). Thread through `BoardContext` (board.tsx) so the sidebar can read it. `BoardProps` is already exported from `lib.ts` — no new export needed.
+- **`src/utils/constants.ts`:** add a `geoElementData: PrimaryElement[]` (point/area/route with new icons). Add three icons to `wireframeAssets/` (pin, polygon, polyline) imported `?react`.
+- **`shapesToolbar.tsx`:** when `geoObjectsEnabled`, append `geoElementData` to `allElements` (additive, after the existing shape/arrow/pencil/text tools). Clicking calls the existing `addElement(name)` + `setCurrentElementInBoard(name)`.
+
+### B7. `addElement` — `src/components/sidebar/primary.tsx`
+
+Add cases to the `switch (label)`:
+
+- **`point`:** build `shapeData` from the geoObjectType catalog (`objectClass:'geo'`, `componentType:'point'`, `metadata:{ svgIcon: DEFAULT_PIN_SVG, resist: DEFAULT_GEO_RESIST, ringRadius }`, `stroke: defaultStrokeColor`). Use the **single-click place** path (same as text-draw: pre-create the lazy element, set `LAST_ADDED_ELEMENT_ID_KEY`, enter a point-place mode; canvas positions it on the click).
+- **`area` / `route`:** enter **multi-click `GEO_DRAW_MODE`**. Store the geo type in localStorage; do **not** pre-create the row. The canvas collects vertices and creates the component on finish. Build defaults (stroke/linewidth) from the catalog.
+
+### B8. Canvas draw lifecycle — `src/newCanvas.tsx`
+
+Mirror the existing `SCENARIO_ARROW_DRAW` / `SCENARIO_TEXT_DRAW` / `SCENARIO_DRAW_SHAPE` branches in the mousedown scenario switch (~line 812).
+
+- **Point (single click):** add a scenario that, like `SCENARIO_TEXT_DRAW`, positions the lazily-mounted point element at `toSurface(e)`, calls `updateComponentVertices`, clears the place-mode keys, and lets the standard insert/persist + history(ADD) run.
+- **Area/Route (multi-click `GEO_DRAW_MODE`):**
+    - mousedown → push a vertex (surface coords); draw a small dot + connecting line (preview overlay, like the example's `currentDots`/`currentLines`).
+    - mousemove → rubber-band preview line from last vertex to cursor.
+    - dblclick / Enter / Esc → finish: validate count (area ≥3, route ≥2 else cancel + clear preview); compute group origin (first vertex), convert vertices to relative, build `shapeData` (`objectClass:'geo'`, type, `metadata.vertices`, stroke/linewidth, fill for area), then route through the **same** store-add + insert(if persisted) + `recordToHistoryLog({type:'ADD'})` path the other shapes use. Clear all preview artifacts and `GEO_DRAW_MODE_KEY`.
+    - Add the geo draw mode to the early-return guards that suppress hover/selection while another draw mode is active (alongside the `ARROW_DRAW_MODE_KEY` / `PENDING_SHAPE_TYPE_KEY` checks, e.g. `newCanvas.tsx:345`, `:2631`).
+
+### B9. Element properties — `src/components/sidebar/elementProperties.tsx`
+
+- Add to `SETS`: `GEO_POINT: ['stroke']`, `GEO_AREA: ['stroke']`, `GEO_ROUTE: ['stroke','strokeWidth','strokeType']`. Add matching labels in the title map.
+- In `resolveSetKey`, map `componentType` `point`→`GEO_POINT`, `area`→`GEO_AREA`, `route`→`GEO_ROUTE` (both selected-component and arrow/draw-mode branches).
+- In `src/utils/applyProperty.ts` (`createApplyProperty`, the single mutation path): when the selected element is an **area** and `stroke` changes, also set `fill = strokeToAreaFill(stroke)` on the **Two.js path only** — do **not** add `fill` to the persisted `_set`. Fill is never stored for geo; it's re-derived from `stroke` on every render (B5/area.tsx).
+
+### B10. Clipboard / draft (follow-up within scope)
+
+- `useCanvasClipboard.ts` + the copy/paste vertex remap in `newCanvas.tsx` (~line 2523, currently special-cased for `pencil`) need the same relative-vertex remap for `area`/`route` `metadata.vertices`. Point copies as-is.
+- The localStorage draft already serializes `metadata`, so vertices persist for free — verify round-trip.
+
+### B11. GraphQL client files — `src/schema/{queries,subscriptions,mutations}/index.ts`
+
+- Add `GET_GEO_OBJECT_TYPES` (query + subscription) mirroring `GET_COMPONENT_TYPES`.
+- Add `objectClass` to the component query/subscription select sets (matches A4).
+- Fetch the geoObjectType catalog in `board.tsx` next to `getComponentTypesData` and expose via context for `primary.tsx`'s `addElement` defaults.
+- Re-run `yarn codegen` after the DB lands; then `yarn typecheck`.
+
+---
+
+## Build order
+
+1. DB: `objectClass` column + `geoObjectType` table + seed (Part A). → `yarn codegen`.
+2. Client foundation: constants, `counterScale.ts`, `strokeToAreaFill`, factories, element components (B1–B5). Renderable via store even before toolbar wiring.
+3. Toolbar + prop + `addElement` (B6–B7).
+4. Canvas draw lifecycle (B8) — point first (simpler), then area/route multi-click.
+5. Properties (B9), clipboard/draft (B10), GraphQL/codegen (B11).
+6. `yarn typecheck`; manual verify in craftmaps (it sets `geoObjectsEnabled`).
+
+## Open items to confirm later
+
+- Point icon swap UI (default pin ships first; arbitrary SVG import is future).
+- Whether point should be resizable (counter-scale + resize interaction needs thought) — default: not resizable, drag-to-move only.
+- Whether `geoObjectsEnabled` should be a finer-grained config (e.g. `enabledGeoTypes: string[]`) — boolean ships first.

--- a/area_polygon_two.js
+++ b/area_polygon_two.js
@@ -1,0 +1,195 @@
+const wrap = document.getElementById('canvas-wrap')
+const btnDraw = document.getElementById('btn-draw')
+const btnClear = document.getElementById('btn-clear')
+const statusEl = document.getElementById('status')
+const polyCountEl = document.getElementById('poly-count')
+
+const two = new Two({
+    type: Two.Types.canvas,
+    width: wrap.clientWidth,
+    height: wrap.clientHeight,
+    autostart: true,
+}).appendTo(wrap)
+
+const canvas = wrap.querySelector('canvas')
+canvas.style.position = 'absolute'
+canvas.style.top = '0'
+canvas.style.left = '0'
+
+let drawing = false
+let currentVertices = []
+let currentDots = []
+let currentLines = []
+let previewLine = null
+let polygons = []
+
+const FILL = 'rgba(226,75,74,0.28)'
+const STROKE = '#A32D2D'
+const STROKE_W = 2
+const DOT_R = 5
+
+function setStatus(msg) {
+    statusEl.textContent = msg
+}
+function updateCount() {
+    const n = polygons.length
+    polyCountEl.textContent = n + ' polygon' + (n !== 1 ? 's' : '')
+}
+
+function startDrawing() {
+    drawing = true
+    currentVertices = []
+    currentDots.forEach((d) => d.remove())
+    currentDots = []
+    currentLines.forEach((l) => l.remove())
+    currentLines = []
+    if (previewLine) {
+        previewLine.remove()
+        previewLine = null
+    }
+    wrap.classList.remove('idle')
+    btnDraw.classList.add('active')
+    btnDraw.setAttribute('aria-pressed', 'true')
+    setStatus('Drawing… click to add points, Esc to finish')
+}
+
+function finishDrawing() {
+    if (!drawing) return
+    drawing = false
+    wrap.classList.add('idle')
+    btnDraw.classList.remove('active')
+    btnDraw.setAttribute('aria-pressed', 'false')
+
+    if (previewLine) {
+        previewLine.remove()
+        previewLine = null
+    }
+
+    if (currentVertices.length < 3) {
+        currentDots.forEach((d) => d.remove())
+        currentLines.forEach((l) => l.remove())
+        currentDots = []
+        currentLines = []
+        setStatus('Need at least 3 points. Click "Draw polygon" to try again.')
+        return
+    }
+
+    currentDots.forEach((d) => d.remove())
+    currentLines.forEach((l) => l.remove())
+    currentDots = []
+    currentLines = []
+
+    const anchors = currentVertices.map((v) => new Two.Anchor(v.x, v.y))
+    const path = new Two.Path(anchors, true, false)
+    path.fill = FILL
+    path.stroke = STROKE
+    path.linewidth = STROKE_W
+    path.opacity = 1
+    two.add(path)
+    polygons.push(path)
+
+    currentVertices = []
+    updateCount()
+    setStatus('Polygon closed. Click "Draw polygon" to add another.')
+}
+
+function addPoint(x, y) {
+    if (!drawing) return
+    currentVertices.push({ x, y })
+
+    const dot = two.makeCircle(x, y, DOT_R)
+    dot.fill = STROKE
+    dot.noStroke()
+    currentDots.push(dot)
+
+    if (currentVertices.length >= 2) {
+        const prev = currentVertices[currentVertices.length - 2]
+        const line = two.makeLine(prev.x, prev.y, x, y)
+        line.stroke = STROKE
+        line.linewidth = STROKE_W
+        line.opacity = 0.6
+        currentLines.push(line)
+    }
+
+    const n = currentVertices.length
+    setStatus(
+        'Drawing… ' +
+            n +
+            ' point' +
+            (n !== 1 ? 's' : '') +
+            ' added. Esc to close.'
+    )
+}
+
+function updatePreview(mx, my) {
+    if (!drawing || currentVertices.length === 0) return
+    const last = currentVertices[currentVertices.length - 1]
+    if (previewLine) {
+        previewLine.vertices[0].set(last.x, last.y)
+        previewLine.vertices[1].set(mx, my)
+    } else {
+        previewLine = two.makeLine(last.x, last.y, mx, my)
+        previewLine.stroke = STROKE
+        previewLine.linewidth = STROKE_W
+        previewLine.opacity = 0.35
+    }
+}
+
+function getPos(e) {
+    const r = wrap.getBoundingClientRect()
+    return { x: e.clientX - r.left, y: e.clientY - r.top }
+}
+
+wrap.addEventListener('click', (e) => {
+    if (!drawing) return
+    const p = getPos(e)
+    addPoint(p.x, p.y)
+})
+
+wrap.addEventListener('mousemove', (e) => {
+    if (!drawing) return
+    const p = getPos(e)
+    updatePreview(p.x, p.y)
+})
+
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && drawing) finishDrawing()
+})
+
+btnDraw.addEventListener('click', () => {
+    if (drawing) {
+        finishDrawing()
+    } else {
+        startDrawing()
+    }
+})
+
+btnClear.addEventListener('click', () => {
+    if (drawing) {
+        drawing = false
+        wrap.classList.add('idle')
+        btnDraw.classList.remove('active')
+        btnDraw.setAttribute('aria-pressed', 'false')
+        if (previewLine) {
+            previewLine.remove()
+            previewLine = null
+        }
+        currentDots.forEach((d) => d.remove())
+        currentLines.forEach((l) => l.remove())
+        currentDots = []
+        currentLines = []
+        currentVertices = []
+    }
+    polygons.forEach((p) => p.remove())
+    polygons = []
+    updateCount()
+    setStatus('Cleared. Click "Draw polygon" to start.')
+})
+
+const ro = new ResizeObserver(() => {
+    two.width = wrap.clientWidth
+    two.height = wrap.clientHeight
+    canvas.width = wrap.clientWidth
+    canvas.height = wrap.clientHeight
+})
+ro.observe(wrap)

--- a/point_two.js
+++ b/point_two.js
@@ -1,0 +1,241 @@
+var two = new Two({
+    fullscreen: true,
+    autostart: true,
+}).appendTo(document.body)
+
+// ── Stage: everything that zooms/pans normally ───────────────────────────────
+var stage = new Two.Group()
+
+// 100 background rectangles
+for (var i = 0; i < 100; i++) {
+    var x = Math.random() * two.width * 2 - two.width
+    var y = Math.random() * two.height * 2 - two.height
+    var size = 50
+    var rect = new Two.Rectangle(x, y, size, size)
+    rect.rotation = Math.random() * Math.PI * 2
+    rect.noStroke().fill = '#3a3530'
+    stage.add(rect)
+}
+
+// Red draggable shape (original)
+var shape = new Two.Rectangle(two.width / 2, two.height / 2, 50, 50)
+shape.noStroke().fill = '#C4501A'
+stage.add(shape)
+
+// ── Pin: lives inside stage so it pans with the world,
+//   but we counter-scale it every frame so it resists zoom ──────────────────
+var PIN_WORLD_X = two.width / 2 - 120
+var PIN_WORLD_Y = two.height / 2 - 80
+
+var pinGroup = new Two.Group()
+
+// Outer ring (fixed amber color)
+var pinRing = new Two.Circle(0, 0, 22)
+pinRing.fill = 'transparent'
+pinRing.stroke = '#E8C87A'
+pinRing.linewidth = 3
+pinGroup.add(pinRing)
+
+// Inner circle — transparent, just anchors the group size
+var pinInner = new Two.Circle(0, 0, 13)
+pinInner.fill = 'transparent'
+pinInner.noStroke()
+pinGroup.add(pinInner)
+
+pinGroup.position.set(PIN_WORLD_X, PIN_WORLD_Y)
+stage.add(pinGroup)
+
+// ── DOM SVG pin icon — overlaid on top of canvas, position synced each frame ─
+var pinIcon = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+pinIcon.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+pinIcon.setAttribute('viewBox', '0 0 24 24')
+pinIcon.setAttribute('width', '20')
+pinIcon.setAttribute('height', '20')
+pinIcon.style.cssText =
+    'position:fixed;pointer-events:none;transform:translate(-50%,-50%)'
+// Standard map-pin path
+pinIcon.innerHTML =
+    '<path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z" fill="#E8C87A"/>'
+document.body.appendChild(pinIcon)
+
+two.add(stage)
+
+// ── ZUI setup ───────────────────────────────────────────────────────────────
+var scaleBadge = document.getElementById('scale-badge')
+var zui,
+    currentScale = 1
+
+addZUI()
+
+// ── Counter-scale the pin on every frame ────────────────────────────────────
+//
+// Goal: at scale=1 (100% zoom) → pin looks normal (scale factor = 1)
+//       at scale=0.5 (50% zoom) → other elements are 50% screen size,
+//                                  pin should be ~50% screen size too
+//                                  (instead of 25% if fully scaled with stage)
+//
+// Formula: pinScale = 1 / (zuiScale ^ RESIST)
+//   RESIST = 0   → pin is fully fixed on screen (ignores zoom completely)
+//   RESIST = 0.5 → pin is "half resistant" — shrinks much slower than world
+//   RESIST = 1   → pin shrinks exactly with the world (no counter-scaling)
+//
+// At zuiScale=0.5:
+//   RESIST=1   → pinScale = 1/0.5   = 2.0 in group space → 1.0 screen = 10% of original intent
+//   RESIST=0.5 → pinScale = 1/0.707 = 1.41 in group space → 0.707 screen size ≈ ~50% visible
+//
+// We pick RESIST = 0.45 for a good "pin on a map" feel.
+
+var RESIST = 0.9
+
+two.bind('update', function () {
+    if (!zui) return
+    currentScale = zui.scale
+    scaleBadge.textContent = 'scale: ' + currentScale.toFixed(2)
+
+    // Counter-scale: inverse of how much the stage has shrunk, softened by RESIST
+    var counterScale = 1 / Math.pow(currentScale, RESIST)
+    pinGroup.scale = counterScale
+
+    // Screen position of the pin world coordinate
+    var wx = PIN_WORLD_X * zui.scale + stage.translation.x
+    var wy = PIN_WORLD_Y * zui.scale + stage.translation.y
+    pinIcon.style.left = wx + 'px'
+    pinIcon.style.top = wy + 'px'
+
+    // Ring screen radius = pinRing.radius(22) * zui.scale * counterScale
+    // Icon is 24x24 viewBox, we want it to fit inside the ring (radius 13 = inner circle)
+    // innerCircle screen radius = 13 * zui.scale * counterScale
+    // So icon size = 2 * 13 * zui.scale * counterScale = 26 * zui.scale * counterScale
+    var screenInnerDiameter = 26 * currentScale * counterScale
+    pinIcon.setAttribute('width', screenInnerDiameter)
+    pinIcon.setAttribute('height', screenInnerDiameter)
+})
+
+// ── ZUI + interaction ────────────────────────────────────────────────────────
+function addZUI() {
+    var domElement = two.renderer.domElement
+    zui = new Two.ZUI(stage)
+    var mouse = new Two.Vector()
+    var touches = {}
+    var distance = 0
+    var dragging = false
+
+    zui.addLimits(0.06, 8)
+
+    domElement.addEventListener('mousedown', mousedown, false)
+    domElement.addEventListener('mousewheel', mousewheel, false)
+    domElement.addEventListener('wheel', mousewheel, false)
+    domElement.addEventListener('touchstart', touchstart, false)
+    domElement.addEventListener('touchmove', touchmove, false)
+    domElement.addEventListener('touchend', touchend, false)
+    domElement.addEventListener('touchcancel', touchend, false)
+
+    function mousedown(e) {
+        mouse.x = e.clientX
+        mouse.y = e.clientY
+        var rect = shape.getBoundingClientRect()
+        dragging =
+            mouse.x > rect.left &&
+            mouse.x < rect.right &&
+            mouse.y > rect.top &&
+            mouse.y < rect.bottom
+        window.addEventListener('mousemove', mousemove, false)
+        window.addEventListener('mouseup', mouseup, false)
+    }
+
+    function mousemove(e) {
+        var dx = e.clientX - mouse.x
+        var dy = e.clientY - mouse.y
+        if (dragging) {
+            shape.position.x += dx / zui.scale
+            shape.position.y += dy / zui.scale
+        } else {
+            zui.translateSurface(dx, dy)
+        }
+        mouse.set(e.clientX, e.clientY)
+    }
+
+    function mouseup(e) {
+        window.removeEventListener('mousemove', mousemove, false)
+        window.removeEventListener('mouseup', mouseup, false)
+    }
+
+    function mousewheel(e) {
+        var dy = (e.wheelDeltaY || -e.deltaY) / 1000
+        zui.zoomBy(dy, e.clientX, e.clientY)
+    }
+
+    function touchstart(e) {
+        switch (e.touches.length) {
+            case 2:
+                pinchstart(e)
+                break
+            case 1:
+                panstart(e)
+                break
+        }
+    }
+
+    function touchmove(e) {
+        switch (e.touches.length) {
+            case 2:
+                pinchmove(e)
+                break
+            case 1:
+                panmove(e)
+                break
+        }
+    }
+
+    function touchend(e) {
+        touches = {}
+        var touch = e.touches[0]
+        if (touch) {
+            mouse.x = touch.clientX
+            mouse.y = touch.clientY
+        }
+    }
+
+    function panstart(e) {
+        var touch = e.touches[0]
+        mouse.x = touch.clientX
+        mouse.y = touch.clientY
+    }
+
+    function panmove(e) {
+        var touch = e.touches[0]
+        var dx = touch.clientX - mouse.x
+        var dy = touch.clientY - mouse.y
+        zui.translateSurface(dx, dy)
+        mouse.set(touch.clientX, touch.clientY)
+    }
+
+    function pinchstart(e) {
+        for (var i = 0; i < e.touches.length; i++) {
+            var touch = e.touches[i]
+            touches[touch.identifier] = touch
+        }
+        var a = touches[0],
+            b = touches[1]
+        var dx = b.clientX - a.clientX
+        var dy = b.clientY - a.clientY
+        distance = Math.sqrt(dx * dx + dy * dy)
+        mouse.x = dx / 2 + a.clientX
+        mouse.y = dy / 2 + a.clientY
+    }
+
+    function pinchmove(e) {
+        for (var i = 0; i < e.touches.length; i++) {
+            var touch = e.touches[i]
+            touches[touch.identifier] = touch
+        }
+        var a = touches[0],
+            b = touches[1]
+        var dx = b.clientX - a.clientX
+        var dy = b.clientY - a.clientY
+        var d = Math.sqrt(dx * dx + dy * dy)
+        var delta = d - distance
+        zui.zoomBy(delta / 250, mouse.x, mouse.y)
+        distance = d
+    }
+}

--- a/route_polyline_two.js
+++ b/route_polyline_two.js
@@ -1,0 +1,197 @@
+const wrap = document.getElementById('canvas-wrap')
+const btnDraw = document.getElementById('btn-draw')
+const btnClear = document.getElementById('btn-clear')
+const statusEl = document.getElementById('status')
+const polyCountEl = document.getElementById('poly-count')
+
+const two = new Two({
+    type: Two.Types.canvas,
+    width: wrap.clientWidth,
+    height: wrap.clientHeight,
+    autostart: true,
+}).appendTo(wrap)
+
+const canvas = wrap.querySelector('canvas')
+canvas.style.position = 'absolute'
+canvas.style.top = '0'
+canvas.style.left = '0'
+
+let drawing = false
+let currentVertices = []
+let currentDots = []
+let currentLines = []
+let previewLine = null
+let routes = []
+
+const STROKE = '#3B82F6'
+const STROKE_W = 2.5
+const DOT_R = 5
+
+function setStatus(msg) {
+    statusEl.textContent = msg
+}
+function updateCount() {
+    const n = routes.length
+    polyCountEl.textContent = n + ' route' + (n !== 1 ? 's' : '')
+}
+
+function startDrawing() {
+    drawing = true
+    currentVertices = []
+    currentDots.forEach((d) => d.remove())
+    currentDots = []
+    currentLines.forEach((l) => l.remove())
+    currentLines = []
+    if (previewLine) {
+        previewLine.remove()
+        previewLine = null
+    }
+    wrap.classList.remove('idle')
+    btnDraw.classList.add('active')
+    btnDraw.setAttribute('aria-pressed', 'true')
+    setStatus('Drawing… click to add points, Esc to finish')
+}
+
+function finishDrawing() {
+    if (!drawing) return
+    drawing = false
+    wrap.classList.add('idle')
+    btnDraw.classList.remove('active')
+    btnDraw.setAttribute('aria-pressed', 'false')
+
+    if (previewLine) {
+        previewLine.remove()
+        previewLine = null
+    }
+
+    if (currentVertices.length < 2) {
+        currentDots.forEach((d) => d.remove())
+        currentLines.forEach((l) => l.remove())
+        currentDots = []
+        currentLines = []
+        setStatus('Need at least 2 points. Click "Draw route" to try again.')
+        return
+    }
+
+    currentDots.forEach((d) => d.remove())
+    currentLines.forEach((l) => l.remove())
+    currentDots = []
+    currentLines = []
+
+    const anchors = currentVertices.map((v) => new Two.Anchor(v.x, v.y))
+    // closed = false → open path (route, not area)
+    const path = new Two.Path(anchors, false, false)
+    path.noFill()
+    path.stroke = STROKE
+    path.linewidth = STROKE_W
+    path.cap = 'round'
+    path.join = 'round'
+    path.opacity = 1
+    two.add(path)
+    routes.push(path)
+
+    currentVertices = []
+    updateCount()
+    setStatus('Route drawn. Click "Draw route" to add another.')
+}
+
+function addPoint(x, y) {
+    if (!drawing) return
+    currentVertices.push({ x, y })
+
+    const dot = two.makeCircle(x, y, DOT_R)
+    dot.fill = STROKE
+    dot.noStroke()
+    currentDots.push(dot)
+
+    if (currentVertices.length >= 2) {
+        const prev = currentVertices[currentVertices.length - 2]
+        const line = two.makeLine(prev.x, prev.y, x, y)
+        line.stroke = STROKE
+        line.linewidth = STROKE_W
+        line.opacity = 0.6
+        currentLines.push(line)
+    }
+
+    const n = currentVertices.length
+    setStatus(
+        'Drawing… ' +
+            n +
+            ' point' +
+            (n !== 1 ? 's' : '') +
+            ' added. Esc to finish.'
+    )
+}
+
+function updatePreview(mx, my) {
+    if (!drawing || currentVertices.length === 0) return
+    const last = currentVertices[currentVertices.length - 1]
+    if (previewLine) {
+        previewLine.vertices[0].set(last.x, last.y)
+        previewLine.vertices[1].set(mx, my)
+    } else {
+        previewLine = two.makeLine(last.x, last.y, mx, my)
+        previewLine.stroke = STROKE
+        previewLine.linewidth = STROKE_W
+        previewLine.opacity = 0.35
+    }
+}
+
+function getPos(e) {
+    const r = wrap.getBoundingClientRect()
+    return { x: e.clientX - r.left, y: e.clientY - r.top }
+}
+
+wrap.addEventListener('click', (e) => {
+    if (!drawing) return
+    const p = getPos(e)
+    addPoint(p.x, p.y)
+})
+
+wrap.addEventListener('mousemove', (e) => {
+    if (!drawing) return
+    const p = getPos(e)
+    updatePreview(p.x, p.y)
+})
+
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && drawing) finishDrawing()
+})
+
+btnDraw.addEventListener('click', () => {
+    if (drawing) {
+        finishDrawing()
+    } else {
+        startDrawing()
+    }
+})
+
+btnClear.addEventListener('click', () => {
+    if (drawing) {
+        drawing = false
+        wrap.classList.add('idle')
+        btnDraw.classList.remove('active')
+        btnDraw.setAttribute('aria-pressed', 'false')
+        if (previewLine) {
+            previewLine.remove()
+            previewLine = null
+        }
+        currentDots.forEach((d) => d.remove())
+        currentLines.forEach((l) => l.remove())
+        currentDots = []
+        currentLines = []
+        currentVertices = []
+    }
+    routes.forEach((p) => p.remove())
+    routes = []
+    updateCount()
+    setStatus('Cleared. Click "Draw route" to start.')
+})
+
+const ro = new ResizeObserver(() => {
+    two.width = wrap.clientWidth
+    two.height = wrap.clientHeight
+    canvas.width = wrap.clientWidth
+    canvas.height = wrap.clientHeight
+})
+ro.observe(wrap)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,11 +150,11 @@ class App extends Component {
                             <Routes>
                                 <Route
                                     path={routes.index}
-                                    element={<BoardViewContainer />}
+                                    element={<BoardViewContainer geoObjectsEnabled />}
                                 />
                                 <Route
                                     path={routes.board}
-                                    element={<BoardViewContainer />}
+                                    element={<BoardViewContainer geoObjectsEnabled />}
                                 />
                                 <Route
                                     path={routes.marketing}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,11 +150,15 @@ class App extends Component {
                             <Routes>
                                 <Route
                                     path={routes.index}
-                                    element={<BoardViewContainer geoObjectsEnabled />}
+                                    element={
+                                        <BoardViewContainer geoObjectsEnabled />
+                                    }
                                 />
                                 <Route
                                     path={routes.board}
-                                    element={<BoardViewContainer geoObjectsEnabled />}
+                                    element={
+                                        <BoardViewContainer geoObjectsEnabled />
+                                    }
                                 />
                                 <Route
                                     path={routes.marketing}

--- a/src/common.css
+++ b/src/common.css
@@ -26,6 +26,19 @@
     cursor: crosshair !important;
 }
 
+/* Pan mode: the whole canvas (and shapes within) shows a grab cursor so the
+   per-shape pointer rule doesn't win; it becomes grabbing while dragging. */
+.pan-mode-active,
+.pan-mode-active .dragger-picker,
+.pan-mode-active text {
+    cursor: grab !important;
+}
+.pan-mode-active.panning,
+.pan-mode-active.panning .dragger-picker,
+.pan-mode-active.panning text {
+    cursor: grabbing !important;
+}
+
 .rounded-50-percent {
     border-radius: 50%;
 }

--- a/src/components/ZoomControls.tsx
+++ b/src/components/ZoomControls.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import type { ReactElement } from 'react'
-import { useBoardContext } from '../views/Board/board'
+import { useBoardContext } from '../views/Board/boardContext'
 import zoomInIcon from '../assets/zoom-in.svg'
 import zoomOutIcon from '../assets/zoom-out.svg'
 

--- a/src/components/elements/area.tsx
+++ b/src/components/elements/area.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef } from 'react'
 import type { ReactElement } from 'react'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 
 import AreaFactory from '../../factory/area'
+import { computeCounterScale } from '../../utils/counterScale'
+import { DEFAULT_GEO_RESIST } from '../../constants/misc'
 
 // See circle.tsx for the rationale on the loose prop bag.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,12 +13,19 @@ type ElementProps = any
 type ShapeLike = any
 
 function Area(props: ElementProps): ReactElement {
-    const { isPencilMode, isArrowDrawMode, isArrowSelected } = useBoardContext()
+    const { isPencilMode, isArrowDrawMode, isArrowSelected, zuiInBoard } =
+        useBoardContext()
 
     const groupRef = useRef<ShapeLike>(null)
     const shapeRef = useRef<ShapeLike>(null)
 
     const two = props.twoJSInstance
+    // metadata for area is the vertex array, so `.resist` is undefined and we
+    // fall back to the default — same expression point.tsx uses.
+    const resist = props.metadata?.resist ?? DEFAULT_GEO_RESIST
+    // Logical (unscaled) stroke width. We counter-scale this on zoom rather
+    // than the whole group, so the polygon geometry stays glued to the world.
+    const baseLinewidth = props.linewidth ?? 2
 
     useEffect(() => {
         const prevX = props.x
@@ -37,6 +46,18 @@ function Area(props: ElementProps): ReactElement {
         } else {
             groupRef.current = group
             shapeRef.current = path
+
+            // Seed the stroke-width counter-scale from the current camera so the
+            // border is legible before the first zoom event fires. Only linewidth
+            // resists the zoom — the geometry stays glued to the world (unlike
+            // point.tsx, which counter-scales the whole group).
+            const initialScale =
+                (zuiInBoard as ShapeLike)?.zui?.scale ?? two?.scene?.scale
+            if (initialScale) {
+                path.linewidth =
+                    baseLinewidth * computeCounterScale(initialScale, resist)
+            }
+
             two.update()
 
             const groupEl = document.getElementById(group.id)
@@ -55,6 +76,29 @@ function Area(props: ElementProps): ReactElement {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
+
+    // Counter-scale only the stroke width on every camera change so the area's
+    // border stays legible when the world zooms out, while the geometry stays
+    // glued to its coordinates. Reads scale from the event each fire — no stale
+    // closure (see the React + Two.js stale-closure note in CLAUDE.md).
+    useEffect(() => {
+        const onZoom = (e: Event): void => {
+            const group = groupRef.current
+            const path = shapeRef.current
+            if (!group || !path) return
+            const scale = (e as CustomEvent<{ scale: number }>).detail?.scale
+            if (!scale) return
+            // Logical width lives on elementData (kept in sync by the property
+            // panel); fall back to the mount-time base.
+            const base = group.elementData?.linewidth ?? baseLinewidth
+            path.linewidth = base * computeCounterScale(scale, resist)
+            two.update()
+        }
+        window.addEventListener('zoomChanged', onZoom as EventListener)
+        return (): void => {
+            window.removeEventListener('zoomChanged', onZoom as EventListener)
+        }
+    }, [two, resist, baseLinewidth])
 
     useEffect(() => {
         const group = groupRef.current

--- a/src/components/elements/area.tsx
+++ b/src/components/elements/area.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useRef } from 'react'
+import type { ReactElement } from 'react'
+import { useBoardContext } from '../../views/Board/board'
+
+import AreaFactory from '../../factory/area'
+
+// See circle.tsx for the rationale on the loose prop bag.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ElementProps = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ShapeLike = any
+
+function Area(props: ElementProps): ReactElement {
+    const { isPencilMode, isArrowDrawMode, isArrowSelected } = useBoardContext()
+
+    const groupRef = useRef<ShapeLike>(null)
+    const shapeRef = useRef<ShapeLike>(null)
+
+    const two = props.twoJSInstance
+
+    useEffect(() => {
+        const prevX = props.x
+        const prevY = props.y
+
+        const elementFactory = new AreaFactory(two, prevX, prevY, {
+            ...props,
+        })
+        const { group, path } = elementFactory.createElement()
+        group.elementData = { ...props.itemData, ...props }
+
+        if (props.parentGroup) {
+            const parentGroup = props.parentGroup
+            path.translation.x = props.properties.x
+            path.translation.y = props.properties.y
+            parentGroup.add(path)
+            two.update()
+        } else {
+            groupRef.current = group
+            shapeRef.current = path
+            two.update()
+
+            const groupEl = document.getElementById(group.id)
+            if (groupEl) {
+                groupEl.setAttribute('class', 'dragger-picker')
+                groupEl.setAttribute('data-component-id', props.id)
+                groupEl.setAttribute(
+                    'data-linewidth',
+                    String(props.linewidth ?? '')
+                )
+            }
+        }
+
+        return (): void => {
+            two.remove(group)
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    useEffect(() => {
+        const group = groupRef.current
+        const el = group ? document.getElementById(group.id) : null
+        if (el) {
+            el.style.pointerEvents =
+                isPencilMode || isArrowDrawMode || isArrowSelected
+                    ? 'none'
+                    : 'auto'
+        }
+    }, [isPencilMode, isArrowDrawMode, isArrowSelected])
+
+    return <React.Fragment />
+}
+
+export default Area

--- a/src/components/elements/circle.tsx
+++ b/src/components/elements/circle.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import type { ReactElement } from 'react'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 
 import CircleFactory from '../../factory/circle'
 import { strokeTypeToDashes } from '../../utils/misc'

--- a/src/components/elements/clusterLayer.tsx
+++ b/src/components/elements/clusterLayer.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
+
+import { useBoardContext } from '../../views/Board/boardContext'
+import type {
+    Cluster,
+    PointScreenInfo,
+    CameraChangeEvent,
+} from '../../types/board'
+
+// Cluster scaffold + render layer (the HTML "cluster" marker variant).
+//
+// craftbase's canvas only knows the screen camera ({scale, tx, ty}), not
+// real-world meters, so it can't decide "4 points within 100m" on its own. The
+// actual grouping is delegated to the `clusterPoints` Board prop (e.g. craftmaps
+// uses its map projection). This layer:
+//   1. gathers every point's world + screen position,
+//   2. hands them + the camera to `clusterPoints`,
+//   3. renders a marker per returned cluster and hides the absorbed pins.
+// With the flag off or no callback supplied it's a pure no-op — that's the
+// "setup" the real 100m grouping (in craftmaps) plugs into.
+//
+// Recompute is driven by a requestAnimationFrame loop gated on a cheap camera +
+// point-count signature, so it's idle until the camera moves or points change.
+
+function setPointDisplay(id: string, display: string): void {
+    const el = document.querySelector(
+        `[data-component-id="${id}"]`
+    ) as HTMLElement | null
+    if (el) el.style.display = display
+}
+
+function ClusterLayer(): ReactElement | null {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ctx = useBoardContext() as any
+    const {
+        pointClusteringEnabled,
+        clusterPoints,
+        twoJSInstance,
+        stateRefForComponentStore,
+    } = ctx
+
+    const [clusters, setClusters] = useState<Cluster[]>([])
+    const hiddenIdsRef = useRef<Set<string>>(new Set())
+    const sigRef = useRef<string>('')
+
+    const active =
+        !!pointClusteringEnabled && typeof clusterPoints === 'function'
+
+    useEffect(() => {
+        const restoreAll = (): void => {
+            hiddenIdsRef.current.forEach((id) => setPointDisplay(id, ''))
+            hiddenIdsRef.current = new Set()
+        }
+
+        if (!active) {
+            restoreAll()
+            setClusters([])
+            sigRef.current = ''
+            return
+        }
+
+        let raf = 0
+        const tick = (): void => {
+            const scene = twoJSInstance?.scene
+            if (scene) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const store = (stateRefForComponentStore?.current ?? {}) as Record<
+                    string,
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    any
+                >
+                const pointIds = Object.keys(store).filter(
+                    (id) => store[id]?.componentType === 'point'
+                )
+                const camera: CameraChangeEvent = {
+                    scale: scene.scale,
+                    tx: scene.translation.x,
+                    ty: scene.translation.y,
+                }
+                const sig = `${camera.scale}|${camera.tx}|${camera.ty}|${pointIds.length}`
+
+                if (sig !== sigRef.current) {
+                    sigRef.current = sig
+
+                    const infos: PointScreenInfo[] = []
+                    pointIds.forEach((id) => {
+                        const rec = store[id]
+                        if (!rec) return
+                        const el = document.querySelector(
+                            `[data-component-id="${id}"]`
+                        )
+                        if (!el) return
+                        const r = el.getBoundingClientRect()
+                        infos.push({
+                            id,
+                            x: rec.x,
+                            y: rec.y,
+                            screenX: r.left + r.width / 2,
+                            screenY: r.top + r.height / 2,
+                            category: rec.metadata?.category as
+                                | string
+                                | undefined,
+                        })
+                    })
+
+                    const result: Cluster[] =
+                        clusterPoints(infos, camera) || []
+
+                    const nextHidden = new Set<string>()
+                    result.forEach((c) =>
+                        c.pointIds.forEach((pid) => nextHidden.add(pid))
+                    )
+                    // Restore pins no longer absorbed; hide newly absorbed ones.
+                    hiddenIdsRef.current.forEach((pid) => {
+                        if (!nextHidden.has(pid)) setPointDisplay(pid, '')
+                    })
+                    nextHidden.forEach((pid) => {
+                        if (!hiddenIdsRef.current.has(pid))
+                            setPointDisplay(pid, 'none')
+                    })
+                    hiddenIdsRef.current = nextHidden
+                    setClusters(result)
+                }
+            }
+            raf = requestAnimationFrame(tick)
+        }
+        raf = requestAnimationFrame(tick)
+
+        return (): void => {
+            cancelAnimationFrame(raf)
+            restoreAll()
+        }
+    }, [active, clusterPoints, twoJSInstance, stateRefForComponentStore])
+
+    if (!active || clusters.length === 0) return null
+
+    return (
+        <>
+            {clusters.map((c) => {
+                const warm = c.variant === 'warm'
+                return (
+                    <div
+                        key={c.id}
+                        className="fixed z-20 flex items-center justify-center rounded-full font-semibold select-none -translate-x-1/2 -translate-y-1/2"
+                        style={{
+                            left: c.screenX,
+                            top: c.screenY,
+                            width: 52,
+                            height: 52,
+                            background: warm ? '#C4901A' : '#1A1612',
+                            color: warm ? '#1A1612' : '#E8C87A',
+                            boxShadow: '3px 3px 0 #C4B89A',
+                            fontSize: 15,
+                            letterSpacing: '-0.03em',
+                        }}
+                    >
+                        <span
+                            className="absolute rounded-full"
+                            style={{
+                                inset: -5,
+                                border: `1.5px solid ${
+                                    warm ? '#E8C87A' : '#C4B89A'
+                                }`,
+                                opacity: 0.5,
+                            }}
+                        />
+                        {c.count}
+                    </div>
+                )
+            })}
+        </>
+    )
+}
+
+export default ClusterLayer

--- a/src/components/elements/diamond.tsx
+++ b/src/components/elements/diamond.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import type { ReactElement } from 'react'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 
 import ElementFactory from '../../factory/diamond'
 import { strokeTypeToDashes } from '../../utils/misc'

--- a/src/components/elements/geoText.tsx
+++ b/src/components/elements/geoText.tsx
@@ -1,0 +1,683 @@
+import React, { useEffect, useState, useRef } from 'react'
+import type { ReactElement } from 'react'
+import interact from 'interactjs'
+import { useImmer } from 'use-immer'
+import { useBoardContext } from '../../views/Board/boardContext'
+
+import { elementOnBlurHandler } from '../../utils/misc'
+import getEditComponents from '../utils/editWrapper'
+import NewTextFactory from '../../factory/newText'
+import {
+    TEXT_SIZES_OBJECT,
+    MOBILE_TEXT_SIZES_OBJECT,
+} from '../../utils/constants'
+import { lineHeightFor } from '../../utils/textLayout'
+import { useMediaQueryUtils } from '../../constants/exportHooks'
+import { computeCounterScale } from '../../utils/counterScale'
+import { DEFAULT_GEO_RESIST } from '../../constants/misc'
+
+// GeoText is a clone of NewText (it reuses the same NewTextFactory for
+// rendering) with one extra behavior: like a point pin, the whole group is
+// counter-scaled on every camera change so the label stays legible when the
+// world zooms way out. See point.tsx for the resist rationale and
+// counterScale.ts for the math. Everything else — multiline editing, resize
+// handles, the floating toolbar contract — matches NewText.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ElementProps = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ShapeLike = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InternalState = Record<string, any>
+
+interface ResizeState {
+    centerX: number
+    centerY: number
+    startDist: number
+    startSize: number
+}
+
+function GeoText(props: ElementProps): ReactElement {
+    const {
+        updateComponentBulkPropertiesInLocalStore,
+        isPencilMode,
+        isArrowDrawMode,
+        isTextDrawMode,
+        isArrowSelected,
+        zuiInBoard,
+    } = useBoardContext()
+
+    const { isMobile } = useMediaQueryUtils()
+    const [showToolbar, toggleToolbar] = useState(false)
+    const [, setShowMobilePanel] = useState(false)
+    const [internalState, setInternalState] = useImmer<InternalState>({})
+    const mobileTriggerRef = useRef<HTMLElement | null>(null)
+    const [textValue, setTextValue] = useState<string>(
+        props?.metadata?.content || ''
+    )
+    const [, setTextSize] = useState<number>(props?.metadata?.fontSize || 36)
+    const textValueRef = useRef(textValue)
+    const twoTextRef = useRef<ShapeLike>(null)
+    // The Two.js group, mirrored to a ref so the zoom listener (registered in
+    // its own effect) can counter-scale it without a stale closure.
+    const groupRef = useRef<ShapeLike>(null)
+    // Satellite Two.Text nodes for lines 2..N (line 1 stays `twoText`), and a
+    // ref to the layout sync so the metadata effect can re-run it.
+    const extraLineNodesRef = useRef<ShapeLike[]>([])
+    const syncMultilineRef = useRef<(() => void) | null>(null)
+
+    const two = props.twoJSInstance
+    // Zoom-resistance strength (0 = screen-fixed, 1 = scales with world).
+    const resist = props.metadata?.resist ?? DEFAULT_GEO_RESIST
+
+    let selectorInstance: ShapeLike = null
+    let groupObject: ShapeLike = null
+
+    function onBlurHandler(e: FocusEvent): void {
+        elementOnBlurHandler(e, selectorInstance, two)
+        if (groupObject) {
+            document
+                .getElementById(`${groupObject.id}`)
+                ?.removeEventListener('keydown', handleKeyDown)
+        }
+    }
+
+    function handleKeyDown(e: KeyboardEvent): void {
+        if (e.keyCode === 8 || e.keyCode === 46) {
+            if (groupObject) {
+                document.getElementById(`${groupObject.id}`)?.blur()
+                props.handleDeleteComponent?.(groupObject)
+                two.remove([groupObject])
+            }
+            two.update()
+        }
+    }
+
+    function onFocusHandler(): void {
+        if (!groupObject) return
+        const el = document.getElementById(`${groupObject.id}`)
+        if (el) {
+            el.style.outline = '0'
+            el.addEventListener('keydown', handleKeyDown)
+        }
+    }
+
+    useEffect(() => {
+        const prevX = props.x
+        const prevY = props.y
+        let handleGlobalMousedown: ((e: MouseEvent) => void) | null = null
+
+        const elementFactory = new NewTextFactory(two, prevX, prevY, props)
+        const { group, twoText } = elementFactory.createElement()
+        group.elementData = { ...props.itemData, ...props }
+        twoText.opacity = props.metadata?.opacity ?? 1
+
+        twoTextRef.current = twoText
+        groupObject = group
+        groupRef.current = group
+
+        // Seed the counter-scale from the current camera so the label is sized
+        // correctly before the first zoom event fires (mirrors point.tsx). The
+        // live scale lives on the nested ZUI instance (fall back to the scene
+        // scale).
+        const initialScale =
+            (zuiInBoard as ShapeLike)?.zui?.scale ?? two?.scene?.scale
+        if (initialScale) {
+            group.scale = computeCounterScale(initialScale, resist)
+        }
+
+        // Multiline rendering: `twoText` holds line 1; satellite Two.Text nodes
+        // hold lines 2..N. We honor only hard newlines (Shift+Enter). The whole
+        // block is vertically centered around the group origin.
+        const syncMultilineLayout = (): void => {
+            const t = twoTextRef.current
+            if (!t) return
+            const lines = (textValueRef.current || '').split('\n')
+            const n = lines.length
+            const lineH = lineHeightFor(t.size || 36)
+            const extra = extraLineNodesRef.current
+
+            t.value = lines[0] ?? ''
+            t.translation.set(0, (0 - (n - 1) / 2) * lineH)
+
+            for (let i = 1; i < n; i++) {
+                let node = extra[i - 1]
+                if (!node) {
+                    node = two.makeText(lines[i] ?? '', 0, 0)
+                    group.add(node)
+                    extra[i - 1] = node
+                }
+                node.value = lines[i] ?? ''
+                node.fill = t.fill
+                node.size = t.size
+                node.family = t.family
+                node.alignment = t.alignment
+                node.baseline = t.baseline
+                node.opacity = t.opacity
+                node.translation.set(0, (i - (n - 1) / 2) * lineH)
+            }
+            if (extra.length > n - 1) {
+                const surplus = extra.splice(Math.max(n - 1, 0))
+                if (surplus.length > 0) group.remove(surplus)
+            }
+            two.update()
+        }
+        syncMultilineRef.current = syncMultilineLayout
+
+        // Union screen box over every line node so the selection rectangle
+        // encloses the whole multiline block (not just line 1). Reads
+        // getBoundingClientRect, so it already reflects the group's counter-scale.
+        const blockRect = (): {
+            left: number
+            right: number
+            top: number
+            bottom: number
+            width: number
+            height: number
+        } => {
+            const nodes = [
+                twoTextRef.current,
+                ...extraLineNodesRef.current,
+            ].filter(Boolean)
+            let L = Infinity
+            let R = -Infinity
+            let T = Infinity
+            let B = -Infinity
+            nodes.forEach((nd) => {
+                const r = nd.getBoundingClientRect(true)
+                L = Math.min(L, r.left)
+                R = Math.max(R, r.right)
+                T = Math.min(T, r.top)
+                B = Math.max(B, r.bottom)
+            })
+            if (L === Infinity) {
+                return twoText.getBoundingClientRect(true)
+            }
+            return {
+                left: L,
+                right: R,
+                top: T,
+                bottom: B,
+                width: R - L,
+                height: B - T,
+            }
+        }
+
+        // Render any persisted multiline content as the stacked block.
+        syncMultilineLayout()
+
+        const { selector } = getEditComponents(two, group, 4)
+        selectorInstance = selector
+        two.update()
+
+        // Resize via corner handles (proportional font-size scaling).
+        const cornerCircles: ShapeLike[] = [
+            selectorInstance.circle1,
+            selectorInstance.circle2,
+            selectorInstance.circle3,
+            selectorInstance.circle4,
+        ].filter(Boolean)
+
+        const resizeCursors = [
+            'nwse-resize', // circle1 = TL
+            'nesw-resize', // circle2 = TR
+            'nwse-resize', // circle3 = BR
+            'nesw-resize', // circle4 = BL
+        ]
+
+        let resizeState: ResizeState | null = null
+
+        const onResizeMouseMove = (e: MouseEvent): void => {
+            if (!resizeState) return
+            const { centerX, centerY, startDist, startSize } = resizeState
+            const currentDist = Math.sqrt(
+                (e.clientX - centerX) ** 2 + (e.clientY - centerY) ** 2
+            )
+            const scale = currentDist / Math.max(startDist, 1)
+            const newSize = Math.round(
+                Math.min(Math.max(startSize * scale, 8), 300)
+            )
+
+            twoText.size = newSize
+            twoText.leading = newSize
+            extraLineNodesRef.current.forEach((nd) => {
+                nd.size = newSize
+                nd.leading = newSize
+            })
+            // Re-stack for the new line height, then box the whole block.
+            syncMultilineLayout()
+
+            const bRect = blockRect()
+            selectorInstance.update(
+                bRect.left - 4,
+                bRect.right + 4,
+                bRect.top - 4,
+                bRect.bottom + 4
+            )
+
+            setTextSize(newSize)
+        }
+
+        const onResizeMouseUp = (): void => {
+            if (!resizeState) return
+            const finalSize = twoText.size
+            resizeState = null
+
+            window.removeEventListener('mousemove', onResizeMouseMove)
+            window.removeEventListener('mouseup', onResizeMouseUp)
+
+            const bRect = blockRect()
+            const newWidth = Math.round(bRect.width || 60)
+            const newHeight = Math.round(bRect.height || twoText.size)
+
+            const resizeMetadata = {
+                ...props.metadata,
+                fontSize: finalSize,
+                content: textValueRef.current,
+            }
+            updateComponentBulkPropertiesInLocalStore(props.id, {
+                width: newWidth,
+                height: newHeight,
+                metadata: resizeMetadata,
+            })
+            if (group.elementData) {
+                group.elementData.metadata = resizeMetadata
+            }
+        }
+
+        cornerCircles.forEach((circle, index) => {
+            const circleElem = circle._renderer?.elem as HTMLElement | undefined
+            if (!circleElem) return
+
+            circleElem.style.cursor = resizeCursors[index] ?? 'pointer'
+            circleElem.style.pointerEvents = 'all'
+
+            circleElem.addEventListener('mousedown', (e: MouseEvent) => {
+                if (selectorInstance.areaGroup.opacity === 0) return
+
+                e.stopPropagation()
+                e.preventDefault()
+
+                const textDomElem = twoText._renderer.elem
+                const textScreenRect = textDomElem.getBoundingClientRect()
+                const centerX = textScreenRect.left + textScreenRect.width / 2
+                const centerY = textScreenRect.top + textScreenRect.height / 2
+
+                const startDist = Math.sqrt(
+                    (e.clientX - centerX) ** 2 + (e.clientY - centerY) ** 2
+                )
+
+                resizeState = {
+                    centerX,
+                    centerY,
+                    startDist,
+                    startSize: twoText.size || 16,
+                }
+
+                window.addEventListener('mousemove', onResizeMouseMove)
+                window.addEventListener('mouseup', onResizeMouseUp)
+            })
+        })
+
+        const groupEl = document.getElementById(group.id)
+        if (groupEl) {
+            groupEl.setAttribute('class', 'dragger-picker')
+            groupEl.setAttribute('data-component-id', props.id)
+        }
+
+        setInternalState((draft) => {
+            draft.group = { id: group.id, data: group }
+            draft.twoText = { id: twoText.id, data: twoText }
+            draft.shape = { id: twoText.id, data: twoText }
+            draft.text = { id: twoText.id, data: twoText }
+            draft.icon = { data: {} }
+        })
+
+        const getGroupElementFromDOM = document.getElementById(`${group.id}`)
+        getGroupElementFromDOM?.addEventListener('focus', onFocusHandler)
+        getGroupElementFromDOM?.addEventListener('blur', onBlurHandler)
+
+        const showTextInput = (): void => {
+            const groupDomElem = document.getElementById(`${group.id}`)
+            if (!groupDomElem) return
+
+            const textDomElem = twoText._renderer.elem as HTMLElement
+            const screenRect = textDomElem.getBoundingClientRect()
+
+            groupDomElem.style.display = 'none'
+
+            // The on-screen text size folds in the group's counter-scale on top
+            // of the scene scale, so the editing overlay must do the same to
+            // line up with the rendered glyphs.
+            const fontSize = twoText.size || 36
+            const sceneScale = two?.scene?.scale || 1
+            const groupScale =
+                typeof group.scale === 'number' ? group.scale : 1
+            const cssFontSize = fontSize * sceneScale * groupScale
+            const lineH = Math.ceil(cssFontSize * 1.6)
+            const vertPad = Math.ceil((lineH - cssFontSize) / 2) + 4
+
+            const input = document.createElement('textarea')
+            const randomId = Math.floor(Math.random() * 90 + 10)
+            input.id = `geo-text-input-area-${randomId}`
+            input.value = textValueRef.current
+            input.rows = 1
+            input.style.border = 'none'
+            input.style.background = 'transparent'
+            input.style.padding = `${vertPad}px 8px`
+            input.style.color = twoText.fill || '#3A342C'
+            input.style.fontSize = `${cssFontSize}px`
+            input.style.fontFamily = twoText.family || 'Caveat'
+            input.style.fontWeight = twoText.weight || 'normal'
+            input.style.lineHeight = `${lineH}px`
+            input.style.letterSpacing = '0px'
+            input.style.textAlign = 'left'
+            input.style.position = 'absolute'
+            input.style.outline = 'none'
+            input.style.resize = 'none'
+            input.style.overflow = 'visible'
+            input.style.whiteSpace = 'pre'
+            input.style.boxSizing = 'border-box'
+            input.className = 'temp-input-area'
+
+            const centerY = screenRect.top + screenRect.height / 2
+            const leftAnchor = screenRect.left - 8
+
+            document.getElementById('main-two-root')?.append(input)
+
+            const measureSpan = document.createElement('span')
+            measureSpan.style.position = 'absolute'
+            measureSpan.style.visibility = 'hidden'
+            measureSpan.style.whiteSpace = 'pre'
+            measureSpan.style.fontSize = `${cssFontSize}px`
+            measureSpan.style.fontFamily = twoText.family || 'Caveat'
+            measureSpan.style.fontWeight = twoText.weight || 'normal'
+            measureSpan.style.lineHeight = `${lineH}px`
+            measureSpan.style.letterSpacing = '0px'
+            measureSpan.style.padding = '0'
+            document.body.appendChild(measureSpan)
+
+            const autoSizeAndCenter = (): void => {
+                const val = input.value || 'M'
+                measureSpan.textContent = val
+
+                const measuredW = measureSpan.offsetWidth
+                const measuredH = measureSpan.offsetHeight
+
+                const contentWidth = Math.max(
+                    measuredW + 40,
+                    screenRect.width + 40,
+                    80
+                )
+                const contentHeight = Math.max(
+                    measuredH + vertPad * 2,
+                    lineH + vertPad * 2
+                )
+
+                input.style.width = `${contentWidth}px`
+                input.style.height = `${contentHeight}px`
+
+                input.style.left = `${leftAnchor}px`
+                input.style.top = `${centerY - contentHeight / 2}px`
+            }
+
+            autoSizeAndCenter()
+
+            input.addEventListener('input', autoSizeAndCenter)
+
+            input.onfocus = function (): void {
+                const bRect = blockRect()
+                selectorInstance.update(
+                    bRect.left - 4,
+                    bRect.right + 4,
+                    bRect.top - 4,
+                    bRect.bottom + 4
+                )
+                selectorInstance.show()
+                two.update()
+            }
+
+            input.focus()
+
+            input.addEventListener('keydown', (event: KeyboardEvent) => {
+                if (event.key === 'Enter') {
+                    if (event.shiftKey) {
+                        // Shift+Enter inserts a newline (textarea is
+                        // whiteSpace:'pre'); hard newlines are preserved.
+                        return
+                    }
+                    // Plain Enter commits and closes the editor.
+                    event.preventDefault()
+                    input.blur()
+                }
+                if (event.key === 'Escape') {
+                    event.preventDefault()
+                    input.blur()
+                }
+            })
+
+            input.addEventListener('blur', () => {
+                input.removeEventListener('input', autoSizeAndCenter)
+                if (measureSpan.parentNode) {
+                    measureSpan.parentNode.removeChild(measureSpan)
+                }
+
+                groupDomElem.style.display = 'block'
+
+                // Raw text — may contain hard newlines from Shift+Enter.
+                const newContent = input.value
+                setTextValue(newContent)
+                textValueRef.current = newContent
+
+                syncMultilineLayout()
+
+                const bRect = blockRect()
+                const newWidth = Math.round(bRect.width || 60)
+                const newHeight = Math.round(bRect.height || twoText.size)
+
+                selectorInstance.update(
+                    bRect.left - 4,
+                    bRect.right + 4,
+                    bRect.top - 4,
+                    bRect.bottom + 4
+                )
+                selectorInstance.hide()
+                two.update()
+
+                const updatedMetadata = {
+                    ...props.metadata,
+                    content: textValueRef.current,
+                }
+                updateComponentBulkPropertiesInLocalStore(props.id, {
+                    width: newWidth,
+                    height: newHeight,
+                    metadata: updatedMetadata,
+                })
+
+                if (group.elementData) {
+                    group.elementData.metadata = updatedMetadata
+                }
+
+                input.remove()
+            })
+        }
+
+        twoText._renderer.elem.addEventListener('dblclick', () => {
+            showTextInput()
+        })
+        getGroupElementFromDOM?.addEventListener('dblclick', () => {
+            showTextInput()
+        })
+
+        const handleTriggerTextInput = (e: Event): void => {
+            const detail = (e as CustomEvent<{ elementId: string }>).detail
+            if (detail?.elementId === props.id) {
+                setTimeout(() => showTextInput(), 100)
+            }
+        }
+        window.addEventListener('triggerTextInput', handleTriggerTextInput)
+
+        interact(`#${group.id}`).on('click', () => {
+            const bRect = blockRect()
+            selector.update(
+                bRect.left - 4,
+                bRect.right + 4,
+                bRect.top - 4,
+                bRect.bottom + 4
+            )
+            two.update()
+            toggleToolbar(true)
+        })
+
+        handleGlobalMousedown = (e: MouseEvent): void => {
+            const path: EventTarget[] = e.composedPath
+                ? e.composedPath()
+                : []
+            const isOnGroup = path.some(
+                (el: EventTarget) => (el as HTMLElement)?.id === group.id
+            )
+            const isOnToolbar = path.some(
+                (el: EventTarget) =>
+                    (el as HTMLElement)?.id === 'floating-toolbar'
+            )
+            const isOnMobileTrigger =
+                mobileTriggerRef.current &&
+                path.includes(mobileTriggerRef.current)
+            if (!isOnGroup && !isOnToolbar && !isOnMobileTrigger) {
+                selectorInstance.hide()
+                toggleToolbar(false)
+                two.update()
+            }
+        }
+        window.addEventListener('mousedown', handleGlobalMousedown)
+
+        return (): void => {
+            window.removeEventListener(
+                'triggerTextInput',
+                handleTriggerTextInput
+            )
+            if (handleGlobalMousedown) {
+                window.removeEventListener('mousedown', handleGlobalMousedown)
+            }
+            window.removeEventListener('mousemove', onResizeMouseMove)
+            window.removeEventListener('mouseup', onResizeMouseUp)
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // Counter-scale the whole group on every camera change so the label stays
+    // legible when the world zooms out (same contract as point.tsx). Reads the
+    // scale from the event each fire — no stale closure.
+    useEffect(() => {
+        const onZoom = (e: Event): void => {
+            const group = groupRef.current
+            if (!group) return
+            const scale = (e as CustomEvent<{ scale: number }>).detail?.scale
+            if (!scale) return
+            group.scale = computeCounterScale(scale, resist)
+            two.update()
+        }
+        window.addEventListener('zoomChanged', onZoom as EventListener)
+        return (): void => {
+            window.removeEventListener('zoomChanged', onZoom as EventListener)
+        }
+    }, [two, resist])
+
+    useEffect(() => {
+        if (internalState?.group?.data) {
+            internalState.group.data.translation.x = props.x
+            internalState.group.data.translation.y = props.y
+            two.update()
+        }
+
+        if (internalState?.twoText?.data) {
+            const twoText = internalState.twoText.data
+
+            if (props.textColor) {
+                twoText.fill = props.textColor
+            }
+            if (props.metadata?.fontSize) {
+                twoText.size = props.metadata.fontSize
+                setTextSize(props.metadata.fontSize)
+            }
+            if (props.metadata?.textFontFamily) {
+                twoText.family = props.metadata.textFontFamily
+            }
+            if (
+                props.metadata?.content !== undefined &&
+                props.metadata.content !== textValueRef.current
+            ) {
+                textValueRef.current = props.metadata.content
+                setTextValue(props.metadata.content)
+            }
+
+            // Propagate style/content changes across every line node and
+            // restack (handles font-size/family/color from the toolbar and
+            // group-apply, plus external content updates).
+            syncMultilineRef.current?.()
+
+            two.update()
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [props.x, props.y, props.textColor, props.metadata])
+
+    // Undo/redo reverts text via the history hook, but ElementRenderWrapper
+    // freezes our props at mount so the metadata effect above never re-fires.
+    // The hook dispatches this event instead; we re-stack through the
+    // component's own multiline path so extraLineNodesRef stays consistent.
+    useEffect(() => {
+        const handleTextReverted = ((
+            e: CustomEvent<{ id: string; content: string }>
+        ): void => {
+            if (e.detail?.id !== props.id) return
+            const content = e.detail.content ?? ''
+            textValueRef.current = content
+            setTextValue(content)
+            syncMultilineRef.current?.()
+            two?.update()
+        }) as EventListener
+        window.addEventListener('standaloneTextReverted', handleTextReverted)
+        return () =>
+            window.removeEventListener(
+                'standaloneTextReverted',
+                handleTextReverted
+            )
+    }, [props.id, two])
+
+    useEffect(() => {
+        if (!showToolbar) setShowMobilePanel(false)
+    }, [showToolbar])
+
+    useEffect(() => {
+        const groupId = internalState?.group?.id
+        const el = groupId ? document.getElementById(groupId) : null
+        if (el) {
+            el.style.pointerEvents =
+                isPencilMode ||
+                isArrowDrawMode ||
+                isTextDrawMode ||
+                isArrowSelected
+                    ? 'none'
+                    : 'auto'
+        }
+    }, [
+        isPencilMode,
+        isArrowDrawMode,
+        isTextDrawMode,
+        isArrowSelected,
+        internalState?.group?.id,
+    ])
+
+    // TEXT_SIZES_OBJECT and MOBILE_TEXT_SIZES_OBJECT used by callbacks
+    // wired in via the toolbar; keep imports referenced via a no-op.
+    void TEXT_SIZES_OBJECT
+    void MOBILE_TEXT_SIZES_OBJECT
+
+    return (
+        <React.Fragment>
+            <div id="two-geo-text"></div>
+        </React.Fragment>
+    )
+}
+
+export default GeoText

--- a/src/components/elements/groupobject.tsx
+++ b/src/components/elements/groupobject.tsx
@@ -5,7 +5,7 @@ import type { ReactElement } from 'react'
 const factoryModules: Record<string, () => Promise<any>> =
     import.meta.glob('../../factory/*.ts')
 import Two from 'two.js'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 import getEditComponents from '../utils/editWrapper'
 import { elementOnBlurHandler } from '../../utils/misc'
 

--- a/src/components/elements/newText.tsx
+++ b/src/components/elements/newText.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef } from 'react'
 import type { ReactElement } from 'react'
 import interact from 'interactjs'
 import { useImmer } from 'use-immer'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 
 import { elementOnBlurHandler } from '../../utils/misc'
 import getEditComponents from '../utils/editWrapper'

--- a/src/components/elements/point.tsx
+++ b/src/components/elements/point.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useRef } from 'react'
+import type { ReactElement } from 'react'
+import { useBoardContext } from '../../views/Board/board'
+
+import PointFactory from '../../factory/point'
+import { computeCounterScale } from '../../utils/counterScale'
+import { DEFAULT_GEO_RESIST } from '../../constants/misc'
+
+// See circle.tsx for the rationale on the loose prop bag.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ElementProps = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ShapeLike = any
+
+function Point(props: ElementProps): ReactElement {
+    const { isPencilMode, isArrowDrawMode, isArrowSelected, zuiInBoard } =
+        useBoardContext()
+
+    const groupRef = useRef<ShapeLike>(null)
+
+    const two = props.twoJSInstance
+    const resist = props.metadata?.resist ?? DEFAULT_GEO_RESIST
+
+    useEffect(() => {
+        const prevX = props.x
+        const prevY = props.y
+
+        const elementFactory = new PointFactory(two, prevX, prevY, {
+            ...props,
+        })
+        const { group } = elementFactory.createElement()
+        group.elementData = { ...props.itemData, ...props }
+
+        if (props.parentGroup) {
+            const parentGroup = props.parentGroup
+            group.translation.x = props.properties.x
+            group.translation.y = props.properties.y
+            parentGroup.add(group)
+            two.update()
+        } else {
+            groupRef.current = group
+
+            // Seed the counter-scale from the current camera so the pin is
+            // sized correctly before the first zoom event fires. The board
+            // context holds the addZUI wrapper ({ zui, ... }) — the live scale
+            // lives on the nested ZUI instance (fall back to the scene scale).
+            const initialScale =
+                (zuiInBoard as ShapeLike)?.zui?.scale ?? two?.scene?.scale
+            if (initialScale) {
+                group.scale = computeCounterScale(initialScale, resist)
+            }
+
+            two.update()
+
+            const groupEl = document.getElementById(group.id)
+            if (groupEl) {
+                groupEl.setAttribute('class', 'dragger-picker')
+                groupEl.setAttribute('data-component-id', props.id)
+            }
+        }
+
+        return (): void => {
+            two.remove(group)
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    // Counter-scale the pin on every camera change so it stays legible when the
+    // world zooms out. Reads the scale from the event each fire — no stale
+    // closure (see the React + Two.js stale-closure note in CLAUDE.md).
+    useEffect(() => {
+        const onZoom = (e: Event): void => {
+            const group = groupRef.current
+            if (!group) return
+            const scale = (e as CustomEvent<{ scale: number }>).detail?.scale
+            if (!scale) return
+            group.scale = computeCounterScale(scale, resist)
+            two.update()
+        }
+        window.addEventListener('zoomChanged', onZoom as EventListener)
+        return (): void => {
+            window.removeEventListener('zoomChanged', onZoom as EventListener)
+        }
+    }, [two, resist])
+
+    useEffect(() => {
+        const group = groupRef.current
+        const el = group ? document.getElementById(group.id) : null
+        if (el) {
+            el.style.pointerEvents =
+                isPencilMode || isArrowDrawMode || isArrowSelected
+                    ? 'none'
+                    : 'auto'
+        }
+    }, [isPencilMode, isArrowDrawMode, isArrowSelected])
+
+    return <React.Fragment />
+}
+
+export default Point

--- a/src/components/elements/point.tsx
+++ b/src/components/elements/point.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import type { ReactElement } from 'react'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 
 import PointFactory from '../../factory/point'
 import { computeCounterScale } from '../../utils/counterScale'

--- a/src/components/elements/pointTooltip.tsx
+++ b/src/components/elements/pointTooltip.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
+
+import { useBoardContext } from '../../views/Board/boardContext'
+import {
+    POINT_CATEGORIES,
+    DEFAULT_POINT_CATEGORY,
+    sizedCategoryIcon,
+} from '../../constants/misc'
+
+// Display-only tooltip card for the currently-selected point (the HTML
+// "tooltip card" variant). Content comes from `metadata.tooltip`; editing is a
+// later task, so it falls back to the category label until then.
+//
+// Anchored to the pin's on-screen box via a requestAnimationFrame loop — the
+// pin is a Two.js node outside React, and pan/zoom/drag emit no single event we
+// can hook, so we re-read getBoundingClientRect each frame while visible (cheap:
+// one node, and we only re-render when the box actually moves).
+
+interface PointTooltipData {
+    title?: string
+    subtitle?: string
+    info?: string
+    tag?: string
+}
+
+interface Box {
+    left: number
+    top: number
+    width: number
+    bottom: number
+}
+
+const TOOLTIP_WIDTH = 160
+
+function PointTooltip(): ReactElement | null {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { selectedComponent } = useBoardContext() as any
+    const [box, setBox] = useState<Box | null>(null)
+    const lastBoxRef = useRef<Box | null>(null)
+
+    const elementData = selectedComponent?.group?.data?.elementData
+    const isPoint = elementData?.componentType === 'point'
+    const componentId: string | undefined = elementData?.id
+
+    useEffect(() => {
+        if (!isPoint || !componentId) {
+            setBox(null)
+            lastBoxRef.current = null
+            return
+        }
+
+        let raf = 0
+        const tick = (): void => {
+            const el = document.querySelector(
+                `[data-component-id="${componentId}"]`
+            )
+            if (el) {
+                const r = el.getBoundingClientRect()
+                const next: Box = {
+                    left: r.left,
+                    top: r.top,
+                    width: r.width,
+                    bottom: r.bottom,
+                }
+                const prev = lastBoxRef.current
+                // Only re-render when the pin actually moved (sub-pixel jitter
+                // from the camera shouldn't churn React every frame).
+                if (
+                    !prev ||
+                    Math.abs(prev.left - next.left) > 0.5 ||
+                    Math.abs(prev.bottom - next.bottom) > 0.5 ||
+                    Math.abs(prev.width - next.width) > 0.5
+                ) {
+                    lastBoxRef.current = next
+                    setBox(next)
+                }
+            }
+            raf = requestAnimationFrame(tick)
+        }
+        raf = requestAnimationFrame(tick)
+        return (): void => cancelAnimationFrame(raf)
+    }, [isPoint, componentId])
+
+    if (!isPoint || !box) return null
+
+    const category = elementData?.metadata?.category ?? DEFAULT_POINT_CATEGORY
+    const cat =
+        POINT_CATEGORIES[category] ?? POINT_CATEGORIES[DEFAULT_POINT_CATEGORY]!
+    const tip: PointTooltipData = elementData?.metadata?.tooltip ?? {}
+
+    const title = tip.title || 'Untitled point'
+    const subtitle = tip.subtitle || `${cat.label} · Active`
+
+    const left = Math.max(
+        8,
+        box.left + box.width / 2 - TOOLTIP_WIDTH / 2
+    )
+    const top = box.bottom + 8
+
+    return (
+        <div
+            className="fixed z-30 rounded-xl border border-border-panel bg-card-bg px-3 py-2.5 pointer-events-none"
+            style={{
+                left,
+                top,
+                width: TOOLTIP_WIDTH,
+                boxShadow: '4px 4px 0 #C4B89A',
+            }}
+        >
+            <div className="flex items-center gap-2 mb-1.5">
+                <span
+                    className="w-6 h-6 rounded-md flex items-center justify-center flex-shrink-0"
+                    style={{
+                        background: cat.bg,
+                        border: cat.border ? `1.5px solid ${cat.border}` : 'none',
+                    }}
+                    dangerouslySetInnerHTML={{
+                        __html: sizedCategoryIcon(cat.svgIcon, 14),
+                    }}
+                />
+                <div className="min-w-0">
+                    <div className="text-xs font-semibold text-ink truncate">
+                        {title}
+                    </div>
+                    <div className="text-[10px] text-ink-muted leading-tight truncate">
+                        {subtitle}
+                    </div>
+                </div>
+            </div>
+            {tip.info ? (
+                <div className="text-[10px] text-ink-muted leading-snug">
+                    {tip.info}
+                </div>
+            ) : null}
+            {tip.tag ? (
+                <span className="inline-block mt-1.5 text-[9px] font-semibold tracking-wide rounded border border-border-panel bg-canvas px-1.5 py-0.5 text-accent-dark uppercase">
+                    {tip.tag}
+                </span>
+            ) : null}
+        </div>
+    )
+}
+
+export default PointTooltip

--- a/src/components/elements/rectangle.tsx
+++ b/src/components/elements/rectangle.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import type { ReactElement } from 'react'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 
 import ElementFactory from '../../factory/rectangle'
 import { strokeTypeToDashes } from '../../utils/misc'

--- a/src/components/elements/route.tsx
+++ b/src/components/elements/route.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef } from 'react'
 import type { ReactElement } from 'react'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 
 import RouteFactory from '../../factory/route'
+import { computeCounterScale } from '../../utils/counterScale'
+import { DEFAULT_GEO_RESIST } from '../../constants/misc'
 
 // See circle.tsx for the rationale on the loose prop bag.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -11,12 +13,19 @@ type ElementProps = any
 type ShapeLike = any
 
 function Route(props: ElementProps): ReactElement {
-    const { isPencilMode, isArrowDrawMode, isArrowSelected } = useBoardContext()
+    const { isPencilMode, isArrowDrawMode, isArrowSelected, zuiInBoard } =
+        useBoardContext()
 
     const groupRef = useRef<ShapeLike>(null)
     const shapeRef = useRef<ShapeLike>(null)
 
     const two = props.twoJSInstance
+    // metadata for route is the vertex array, so `.resist` is undefined and we
+    // fall back to the default — same expression point.tsx uses.
+    const resist = props.metadata?.resist ?? DEFAULT_GEO_RESIST
+    // Logical (unscaled) stroke width. We counter-scale this on zoom rather
+    // than the whole group, so the polyline geometry stays glued to the world.
+    const baseLinewidth = props.linewidth ?? 2.5
 
     useEffect(() => {
         const prevX = props.x
@@ -37,6 +46,18 @@ function Route(props: ElementProps): ReactElement {
         } else {
             groupRef.current = group
             shapeRef.current = path
+
+            // Seed the stroke-width counter-scale from the current camera so the
+            // line is legible before the first zoom event fires. Only linewidth
+            // resists the zoom — the geometry stays glued to the world (unlike
+            // point.tsx, which counter-scales the whole group).
+            const initialScale =
+                (zuiInBoard as ShapeLike)?.zui?.scale ?? two?.scene?.scale
+            if (initialScale) {
+                path.linewidth =
+                    baseLinewidth * computeCounterScale(initialScale, resist)
+            }
+
             two.update()
 
             const groupEl = document.getElementById(group.id)
@@ -55,6 +76,29 @@ function Route(props: ElementProps): ReactElement {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
+
+    // Counter-scale only the stroke width on every camera change so the route
+    // stays legible when the world zooms out, while the geometry stays glued to
+    // its coordinates. Reads scale from the event each fire — no stale closure
+    // (see the React + Two.js stale-closure note in CLAUDE.md).
+    useEffect(() => {
+        const onZoom = (e: Event): void => {
+            const group = groupRef.current
+            const path = shapeRef.current
+            if (!group || !path) return
+            const scale = (e as CustomEvent<{ scale: number }>).detail?.scale
+            if (!scale) return
+            // Logical width lives on elementData (kept in sync by the property
+            // panel); fall back to the mount-time base.
+            const base = group.elementData?.linewidth ?? baseLinewidth
+            path.linewidth = base * computeCounterScale(scale, resist)
+            two.update()
+        }
+        window.addEventListener('zoomChanged', onZoom as EventListener)
+        return (): void => {
+            window.removeEventListener('zoomChanged', onZoom as EventListener)
+        }
+    }, [two, resist, baseLinewidth])
 
     useEffect(() => {
         const group = groupRef.current

--- a/src/components/elements/route.tsx
+++ b/src/components/elements/route.tsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useRef } from 'react'
+import type { ReactElement } from 'react'
+import { useBoardContext } from '../../views/Board/board'
+
+import RouteFactory from '../../factory/route'
+
+// See circle.tsx for the rationale on the loose prop bag.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ElementProps = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ShapeLike = any
+
+function Route(props: ElementProps): ReactElement {
+    const { isPencilMode, isArrowDrawMode, isArrowSelected } = useBoardContext()
+
+    const groupRef = useRef<ShapeLike>(null)
+    const shapeRef = useRef<ShapeLike>(null)
+
+    const two = props.twoJSInstance
+
+    useEffect(() => {
+        const prevX = props.x
+        const prevY = props.y
+
+        const elementFactory = new RouteFactory(two, prevX, prevY, {
+            ...props,
+        })
+        const { group, path } = elementFactory.createElement()
+        group.elementData = { ...props.itemData, ...props }
+
+        if (props.parentGroup) {
+            const parentGroup = props.parentGroup
+            path.translation.x = props.properties.x
+            path.translation.y = props.properties.y
+            parentGroup.add(path)
+            two.update()
+        } else {
+            groupRef.current = group
+            shapeRef.current = path
+            two.update()
+
+            const groupEl = document.getElementById(group.id)
+            if (groupEl) {
+                groupEl.setAttribute('class', 'dragger-picker')
+                groupEl.setAttribute('data-component-id', props.id)
+                groupEl.setAttribute(
+                    'data-linewidth',
+                    String(props.linewidth ?? '')
+                )
+            }
+        }
+
+        return (): void => {
+            two.remove(group)
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    useEffect(() => {
+        const group = groupRef.current
+        const el = group ? document.getElementById(group.id) : null
+        if (el) {
+            el.style.pointerEvents =
+                isPencilMode || isArrowDrawMode || isArrowSelected
+                    ? 'none'
+                    : 'auto'
+        }
+    }, [isPencilMode, isArrowDrawMode, isArrowSelected])
+
+    return <React.Fragment />
+}
+
+export default Route

--- a/src/components/sidebar/elementProperties.tsx
+++ b/src/components/sidebar/elementProperties.tsx
@@ -4,7 +4,7 @@ import { useBoardContext } from '../../views/Board/board'
 import { useMediaQueryUtils } from '../../constants/exportHooks'
 import ColorPicker from '../utils/colorPicker'
 import OpacitySlider from '../utils/opacitySlider'
-import { TEXT_SIZES_ARRAY } from '../../utils/constants'
+import { TEXT_SIZES_ARRAY, fillEssentialShades } from '../../utils/constants'
 import { MIXED, inspectGroupValues } from '../../utils/groupInspect'
 
 const STROKE_TYPES = [
@@ -528,6 +528,7 @@ const ElementPropertiesToolbar = () => {
                         onChangeComplete={handle('fill')}
                         isExpanded={expandedSection === 'fill'}
                         onToggleExpand={() => toggleSection('fill')}
+                        essentialColors={fillEssentialShades}
                     />
                 </div>
             )}

--- a/src/components/sidebar/elementProperties.tsx
+++ b/src/components/sidebar/elementProperties.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect, useMemo, useState } from 'react'
 
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 import { useMediaQueryUtils } from '../../constants/exportHooks'
 import ColorPicker from '../utils/colorPicker'
 import OpacitySlider from '../utils/opacitySlider'
@@ -28,8 +28,8 @@ const SETS = {
     TEXT: ['textColor', 'textSize', 'textFont', 'opacity'],
     // Geo objects: stroke-centric. Area's fill is auto-derived from stroke, so
     // no fill control — but its outline still takes width/type like a route.
-    // Point exposes only its ring/icon color.
-    GEO_POINT: ['stroke'],
+    // Point has no edit-area set: its category is chosen from the point drawer
+    // in the shapes toolbar (resolveSetKey returns null for points).
     GEO_AREA: ['stroke', 'strokeWidth', 'strokeType'],
     GEO_ROUTE: ['stroke', 'strokeWidth', 'strokeType'],
     RECT_WITH_TEXT: [
@@ -64,7 +64,6 @@ const SET_LABELS = {
     TEXT: 'Text',
     RECT_WITH_TEXT: 'Shape',
     GROUP: 'Group',
-    GEO_POINT: 'Point',
     GEO_AREA: 'Area',
     GEO_ROUTE: 'Route',
 }
@@ -102,8 +101,9 @@ function resolveSetKey({
         const elementType =
             selectedComponent?.group?.data?.elementData?.componentType
         // Geo objects checked first: area/route are path-typed and would
-        // otherwise fall into the SHAPE branch below.
-        if (elementType === 'point') return 'GEO_POINT'
+        // otherwise fall into the SHAPE branch below. Points have no edit-area
+        // panel — their category is set from the toolbar drawer.
+        if (elementType === 'point') return null
         if (elementType === 'area') return 'GEO_AREA'
         if (elementType === 'route') return 'GEO_ROUTE'
         // rectangle/diamond/circle all carry text the same way — show the
@@ -143,7 +143,7 @@ function resolveSetKey({
     // Geo draw modes: the toolbar tool is active but nothing is selected yet.
     // Surface the geo property panel so stroke edits seed the next draw — the
     // same way pencil mode shows the pencil panel before the first stroke.
-    if (currentElement === 'point') return 'GEO_POINT'
+    // Point is excluded: its category lives in the toolbar drawer, not here.
     if (currentElement === 'area') return 'GEO_AREA'
     if (currentElement === 'route') return 'GEO_ROUTE'
     return 'SHAPE'

--- a/src/components/sidebar/elementProperties.tsx
+++ b/src/components/sidebar/elementProperties.tsx
@@ -26,6 +26,12 @@ const SETS = {
     ARROW: ['stroke', 'strokeWidth', 'strokeType', 'opacity'],
     PENCIL: ['stroke', 'strokeWidth', 'strokeType'],
     TEXT: ['textColor', 'textSize', 'textFont', 'opacity'],
+    // Geo objects: stroke-centric. Area's fill is auto-derived from stroke, so
+    // no fill control — but its outline still takes width/type like a route.
+    // Point exposes only its ring/icon color.
+    GEO_POINT: ['stroke'],
+    GEO_AREA: ['stroke', 'strokeWidth', 'strokeType'],
+    GEO_ROUTE: ['stroke', 'strokeWidth', 'strokeType'],
     RECT_WITH_TEXT: [
         'fill',
         'stroke',
@@ -58,6 +64,9 @@ const SET_LABELS = {
     TEXT: 'Text',
     RECT_WITH_TEXT: 'Shape',
     GROUP: 'Group',
+    GEO_POINT: 'Point',
+    GEO_AREA: 'Area',
+    GEO_ROUTE: 'Route',
 }
 
 interface ResolveSetKeyOptions {
@@ -69,6 +78,9 @@ interface ResolveSetKeyOptions {
     selectedGroup: any
     isArrowDrawMode: boolean
     isTextDrawMode: boolean
+    // Active tool from the toolbar (e.g. 'route'/'area'/'point' while a geo
+    // draw is in progress, before any vertex/element is selected).
+    currentElement: string | null
 }
 
 function resolveSetKey({
@@ -78,6 +90,7 @@ function resolveSetKey({
     selectedGroup,
     isArrowDrawMode,
     isTextDrawMode,
+    currentElement,
 }: ResolveSetKeyOptions): string | null {
     // A focused group beats every other mode — show the union toolbar.
     if (selectedGroup) return 'GROUP'
@@ -88,6 +101,11 @@ function resolveSetKey({
         const hasText = typeof selectedComponent?.text?.data?.value === 'string'
         const elementType =
             selectedComponent?.group?.data?.elementData?.componentType
+        // Geo objects checked first: area/route are path-typed and would
+        // otherwise fall into the SHAPE branch below.
+        if (elementType === 'point') return 'GEO_POINT'
+        if (elementType === 'area') return 'GEO_AREA'
+        if (elementType === 'route') return 'GEO_ROUTE'
         // rectangle/diamond/circle all carry text the same way — show the
         // shape+text toolbar (text size/color/font) for any of them.
         const isShapeWithText =
@@ -122,6 +140,12 @@ function resolveSetKey({
     }
     if (isArrowDrawMode) return 'ARROW'
     if (isTextDrawMode) return 'TEXT'
+    // Geo draw modes: the toolbar tool is active but nothing is selected yet.
+    // Surface the geo property panel so stroke edits seed the next draw — the
+    // same way pencil mode shows the pencil panel before the first stroke.
+    if (currentElement === 'point') return 'GEO_POINT'
+    if (currentElement === 'area') return 'GEO_AREA'
+    if (currentElement === 'route') return 'GEO_ROUTE'
     return 'SHAPE'
 }
 
@@ -213,7 +237,13 @@ const SectionLabel = ({ children }: { children: React.ReactNode }) => (
 )
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const StrokeWidthRow = ({ value, onChange }: { value: any; onChange: (v: number) => void }) => (
+const StrokeWidthRow = ({
+    value,
+    onChange,
+}: {
+    value: any
+    onChange: (v: number) => void
+}) => (
     <div id="stroke-width-section" className="pt-2 px-2">
         <SectionLabel>Stroke Width</SectionLabel>
         <div className="flex gap-2">
@@ -260,7 +290,13 @@ const StrokeWidthRow = ({ value, onChange }: { value: any; onChange: (v: number)
 )
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const StrokeTypeRow = ({ value, onChange }: { value: any; onChange: (v: string) => void }) => (
+const StrokeTypeRow = ({
+    value,
+    onChange,
+}: {
+    value: any
+    onChange: (v: string) => void
+}) => (
     <div id="stroke-type-section" className="pt-3 px-2">
         <SectionLabel>Stroke Type</SectionLabel>
         <div className="flex gap-2">
@@ -296,7 +332,13 @@ const StrokeTypeRow = ({ value, onChange }: { value: any; onChange: (v: string) 
     </div>
 )
 
-const TextSizeRow = ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+const TextSizeRow = ({
+    value,
+    onChange,
+}: {
+    value: string
+    onChange: (v: string) => void
+}) => (
     <div className="pt-3 px-2">
         <SectionLabel>Text Size</SectionLabel>
         <div className="flex flex-row gap-2">
@@ -320,7 +362,13 @@ const TextSizeRow = ({ value, onChange }: { value: string; onChange: (v: string)
     </div>
 )
 
-const FontFamilyRow = ({ value, onChange }: { value: string; onChange: (v: string) => void }) => {
+const FontFamilyRow = ({
+    value,
+    onChange,
+}: {
+    value: string
+    onChange: (v: string) => void
+}) => {
     const families = [
         { label: 'Caveat', family: 'Caveat' },
         { label: 'Geist', family: 'Geist' },
@@ -361,6 +409,7 @@ const ElementPropertiesToolbar = () => {
         isRubberMode,
         selectedComponent,
         selectedGroup,
+        currentElement,
         applyProperty,
         applyGroupProperty,
         showMobileToolbarPanel,
@@ -385,6 +434,7 @@ const ElementPropertiesToolbar = () => {
                 selectedGroup,
                 isArrowDrawMode,
                 isTextDrawMode,
+                currentElement,
             }),
         [
             isRubberMode,
@@ -393,6 +443,7 @@ const ElementPropertiesToolbar = () => {
             selectedGroup,
             isArrowDrawMode,
             isTextDrawMode,
+            currentElement,
         ]
     )
 
@@ -462,30 +513,32 @@ const ElementPropertiesToolbar = () => {
 
     const sections = SETS[setKey as keyof typeof SETS]
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const handle = (key: string) => (val: any): void => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        setValues((prev: any) => ({ ...prev, [key]: val }))
-        if (selectedGroup) {
-            // textSize comes through as a label (e.g. 'M'); resolve to the
-            // numeric Two.js size before forwarding to the bulk apply path.
-            // The single-element path goes through handleTextSizeChange which
-            // does this conversion internally; the group path doesn't, so we
-            // do it here.
-            if (key === 'textSize') {
-                const entry = TEXT_SIZES_ARRAY.find((s) => s.label === val)
-                const numeric = entry
-                    ? isMobile
-                        ? entry.mobileValue
-                        : entry.value
-                    : val
-                applyGroupProperty?.(key, numeric)
-            } else {
-                applyGroupProperty?.(key, val)
+    const handle =
+        (key: string) =>
+        (val: any): void => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            setValues((prev: any) => ({ ...prev, [key]: val }))
+            if (selectedGroup) {
+                // textSize comes through as a label (e.g. 'M'); resolve to the
+                // numeric Two.js size before forwarding to the bulk apply path.
+                // The single-element path goes through handleTextSizeChange which
+                // does this conversion internally; the group path doesn't, so we
+                // do it here.
+                if (key === 'textSize') {
+                    const entry = TEXT_SIZES_ARRAY.find((s) => s.label === val)
+                    const numeric = entry
+                        ? isMobile
+                            ? entry.mobileValue
+                            : entry.value
+                        : val
+                    applyGroupProperty?.(key, numeric)
+                } else {
+                    applyGroupProperty?.(key, val)
+                }
+                return
             }
-            return
+            applyProperty?.(key, val)
         }
-        applyProperty?.(key, val)
-    }
 
     return (
         <div

--- a/src/components/sidebar/elementProperties.tsx
+++ b/src/components/sidebar/elementProperties.tsx
@@ -6,6 +6,7 @@ import ColorPicker from '../utils/colorPicker'
 import OpacitySlider from '../utils/opacitySlider'
 import { TEXT_SIZES_ARRAY, fillEssentialShades } from '../../utils/constants'
 import { MIXED, inspectGroupValues } from '../../utils/groupInspect'
+import { isStandaloneTextType } from '../../constants/misc'
 
 const STROKE_TYPES = [
     { label: '—', value: 'solid' },
@@ -125,7 +126,7 @@ function resolveSetKey({
         )
             return 'SHAPE'
         if (shapeType === 'arrowLine') return 'ARROW'
-        if (shapeType === 'newText') return 'TEXT'
+        if (isStandaloneTextType(shapeType)) return 'TEXT'
         // Diamond is a custom Path; the elementData carries the type.
         if (
             elementType === 'diamond' ||
@@ -134,7 +135,7 @@ function resolveSetKey({
         )
             return 'SHAPE'
         if (elementType === 'arrowLine') return 'ARROW'
-        if (elementType === 'newText') return 'TEXT'
+        if (isStandaloneTextType(elementType)) return 'TEXT'
         if (elementType === 'pencil') return 'PENCIL'
         return 'SHAPE'
     }
@@ -205,7 +206,7 @@ function readEffectiveValues({
 
     // For rectangle-with-text + plain text, the text properties live in
     // different places. Resolve here so the rest is symmetric.
-    const isText = selectedComponent?.shape?.type === 'newText'
+    const isText = isStandaloneTextType(selectedComponent?.shape?.type)
     const textNode = isText ? shapeData : textData
 
     const textSizeNumeric = textNode?.size

--- a/src/components/sidebar/menuDrawer.tsx
+++ b/src/components/sidebar/menuDrawer.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect } from 'react'
 import type { ReactElement } from 'react'
 import { Link } from 'react-router-dom'
 import routes from '../../routes'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 import Modal from '../common/modal'
 import Button from '../common/button'
 

--- a/src/components/sidebar/primary.tsx
+++ b/src/components/sidebar/primary.tsx
@@ -9,6 +9,17 @@ import { generateUUID } from '../../utils/misc'
 import { useBoardContext } from '../../views/Board/board'
 import { useMediaQueryUtils } from '../../constants/exportHooks'
 import type { ComponentRecord } from '../../types/board'
+import {
+    GEO_TYPE_DEFAULTS,
+    DEFAULT_PIN_SVG,
+    DEFAULT_GEO_RESIST,
+    DEFAULT_GEO_RING_RADIUS,
+    GEO_DRAW_MODE_KEY,
+    GEO_DRAW_TYPE_KEY,
+    GEO_DRAW_PROPS_KEY,
+    GEO_POINT_PLACE_MODE_KEY,
+    LAST_ADDED_ELEMENT_ID_KEY,
+} from '../../constants/misc'
 
 import './sidebar.css'
 import ShareLinkPopup from './shareLinkPopup'
@@ -200,6 +211,87 @@ const PrimarySidebar = (): ReactElement => {
         enableTextDrawMode()
     }
 
+    // Point: single click-to-place. Pre-create the element off-screen (like the
+    // text/arrow flow) then let the canvas position it on the next click.
+    const handlePointElement = (): void => {
+        togglePencilMode(false)
+        togglePointer(false)
+
+        const userId = localStorage.getItem('userId')
+        const generateId = generateUUID()
+        const geoDef = GEO_TYPE_DEFAULTS.point
+
+        const shapeData: ComponentRecord = {
+            id: generateId,
+            componentType: 'point',
+            objectClass: 'geo',
+            linewidth: geoDef.linewidth,
+            strokeType: null,
+            stroke: geoDef.stroke,
+            children: {},
+            x: -9999,
+            y: -9999,
+            x1: 0,
+            x2: 0,
+            y1: 0,
+            y2: 0,
+            boardId,
+            boardName: null,
+            radius: null,
+            iconStroke: null,
+            isDummy: null,
+            createdAt: null,
+            metadata: {
+                svgIcon: DEFAULT_PIN_SVG,
+                resist: DEFAULT_GEO_RESIST,
+                ringRadius: DEFAULT_GEO_RING_RADIUS,
+            },
+            width: DEFAULT_GEO_RING_RADIUS * 2,
+            height: DEFAULT_GEO_RING_RADIUS * 2,
+            fill: 'transparent',
+            textColor: null,
+            updatedBy: userId,
+        }
+
+        updateLastAddedElement(shapeData)
+        localStorage.setItem(GEO_POINT_PLACE_MODE_KEY, 'true')
+        localStorage.setItem(LAST_ADDED_ELEMENT_ID_KEY, generateId)
+        addToLocalComponentStore(
+            shapeData.id,
+            shapeData.componentType,
+            shapeData
+        )
+        const root = document.getElementById('main-two-root')
+        if (root) root.style.cursor = 'crosshair'
+    }
+
+    // Area / Route: multi-click vertex placement. Don't pre-create — stash the
+    // base props and let the canvas collect vertices and build on finish.
+    const handleGeoMultiClick = (label: 'area' | 'route'): void => {
+        togglePencilMode(false)
+        togglePointer(false)
+
+        const geoDef = GEO_TYPE_DEFAULTS[label]
+        const baseProps = {
+            componentType: label,
+            objectClass: 'geo' as const,
+            stroke: geoDef.stroke,
+            linewidth: geoDef.linewidth,
+            strokeType: null,
+            fill: 'transparent',
+            boardId,
+            boardName: null,
+            textColor: null,
+            updatedBy: localStorage.getItem('userId'),
+        }
+
+        localStorage.setItem(GEO_DRAW_MODE_KEY, 'true')
+        localStorage.setItem(GEO_DRAW_TYPE_KEY, label)
+        localStorage.setItem(GEO_DRAW_PROPS_KEY, JSON.stringify(baseProps))
+        const root = document.getElementById('main-two-root')
+        if (root) root.style.cursor = 'crosshair'
+    }
+
     const addElement = (label: string): void => {
         cancelPendingElement()
         if (label !== 'rubber') setRubberModeInBoard(false)
@@ -224,6 +316,13 @@ const PrimarySidebar = (): ReactElement => {
                 break
             case 'text':
                 handleTextElement()
+                break
+            case 'point':
+                handlePointElement()
+                break
+            case 'area':
+            case 'route':
+                handleGeoMultiClick(label)
                 break
             default: {
                 togglePencilMode(false)

--- a/src/components/sidebar/primary.tsx
+++ b/src/components/sidebar/primary.tsx
@@ -6,12 +6,13 @@ import ShapesToolbar from './shapesToolbar'
 import { GET_COMPONENT_TYPES } from '../../schema/queries'
 import SpinnerWithSize from '../common/spinnerWithSize'
 import { generateUUID } from '../../utils/misc'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 import { useMediaQueryUtils } from '../../constants/exportHooks'
 import type { ComponentRecord } from '../../types/board'
 import {
     GEO_TYPE_DEFAULTS,
-    DEFAULT_PIN_SVG,
+    POINT_CATEGORIES,
+    DEFAULT_POINT_CATEGORY,
     DEFAULT_GEO_RESIST,
     DEFAULT_GEO_RING_RADIUS,
     GEO_DRAW_MODE_KEY,
@@ -213,13 +214,21 @@ const PrimarySidebar = (): ReactElement => {
 
     // Point: single click-to-place. Pre-create the element off-screen (like the
     // text/arrow flow) then let the canvas position it on the next click.
-    const handlePointElement = (): void => {
+    const handlePointElement = (categoryArg?: string): void => {
         togglePencilMode(false)
         togglePointer(false)
 
         const userId = localStorage.getItem('userId')
         const generateId = generateUUID()
         const geoDef = GEO_TYPE_DEFAULTS.point
+        // Category is chosen up front from the point drawer (defaults to the
+        // generic pin). It drives the pin's fill/icon — stroke/fill mirror the
+        // category color for any legacy reads.
+        const category =
+            categoryArg && POINT_CATEGORIES[categoryArg]
+                ? categoryArg
+                : DEFAULT_POINT_CATEGORY
+        const cat = POINT_CATEGORIES[category]!
 
         const shapeData: ComponentRecord = {
             id: generateId,
@@ -227,7 +236,7 @@ const PrimarySidebar = (): ReactElement => {
             objectClass: 'geo',
             linewidth: geoDef.linewidth,
             strokeType: null,
-            stroke: geoDef.stroke,
+            stroke: cat.bg,
             children: {},
             x: -9999,
             y: -9999,
@@ -242,13 +251,14 @@ const PrimarySidebar = (): ReactElement => {
             isDummy: null,
             createdAt: null,
             metadata: {
-                svgIcon: DEFAULT_PIN_SVG,
+                category,
+                svgIcon: cat.svgIcon,
                 resist: DEFAULT_GEO_RESIST,
                 ringRadius: DEFAULT_GEO_RING_RADIUS,
             },
             width: DEFAULT_GEO_RING_RADIUS * 2,
             height: DEFAULT_GEO_RING_RADIUS * 2,
-            fill: 'transparent',
+            fill: cat.bg,
             textColor: null,
             updatedBy: userId,
         }
@@ -292,7 +302,7 @@ const PrimarySidebar = (): ReactElement => {
         if (root) root.style.cursor = 'crosshair'
     }
 
-    const addElement = (label: string): void => {
+    const addElement = (label: string, category?: string): void => {
         cancelPendingElement()
         if (label !== 'rubber') setRubberModeInBoard(false)
         if (label !== 'pan') togglePanMode(false)
@@ -318,7 +328,7 @@ const PrimarySidebar = (): ReactElement => {
                 handleTextElement()
                 break
             case 'point':
-                handlePointElement()
+                handlePointElement(category)
                 break
             case 'area':
             case 'route':

--- a/src/components/sidebar/primary.tsx
+++ b/src/components/sidebar/primary.tsx
@@ -195,7 +195,9 @@ const PrimarySidebar = (): ReactElement => {
         )
     }
 
-    const handleTextElement = (): void => {
+    const handleTextElement = (
+        componentType: 'newText' | 'geoText' = 'newText'
+    ): void => {
         const savingEl = document.getElementById('show-saving-loader')
         if (savingEl) {
             savingEl.style.opacity = '1'
@@ -209,7 +211,7 @@ const PrimarySidebar = (): ReactElement => {
             }
         }, 100)
 
-        enableTextDrawMode()
+        enableTextDrawMode(componentType)
     }
 
     // Point: single click-to-place. Pre-create the element off-screen (like the
@@ -326,6 +328,11 @@ const PrimarySidebar = (): ReactElement => {
                 break
             case 'text':
                 handleTextElement()
+                break
+            case 'geoText':
+                // Same one-shot click-to-place flow as text, but tagged so the
+                // canvas renders the zoom-resistant geoText component.
+                handleTextElement('geoText')
                 break
             case 'point':
                 handlePointElement(category)

--- a/src/components/sidebar/shapesToolbar.tsx
+++ b/src/components/sidebar/shapesToolbar.tsx
@@ -19,6 +19,20 @@ const allElementsRaw = staticPrimaryElementData.flatMap(
     (section) => section.elements
 )
 
+// Whiteboard-only tools hidden once geo objects are enabled — the geo workflow
+// uses point/area/route + the zoom-resistant geoText instead. 'shapes' is the
+// mobile drawer; rectangle/circle/diamond are its desktop-flattened children.
+// 'text' is replaced by 'geoText' (see geoElementData).
+const GEO_HIDDEN_TOOLS = new Set([
+    'shapes',
+    'rectangle',
+    'circle',
+    'diamond',
+    'arrowLine',
+    'pencil',
+    'text',
+])
+
 const flattenShapesForDesktop = (
     elements: PrimaryElement[]
 ): PrimaryElement[] =>
@@ -84,23 +98,41 @@ const ShapesToolbar = ({ addElement }: ShapesToolbarProps): ReactElement => {
     // otherwise the usual pointer/select default.
     const homeTool = geoObjectsEnabled ? 'pan' : 'pointer'
 
-    const allElements = (
-        isMobile ? allElementsRaw : flattenShapesForDesktop(allElementsRaw)
-    )
-        .filter((el) => {
-            // Pan is normally mobile-only; surface it on desktop too when geo
-            // objects are enabled so the default tool is reachable.
-            if (el.mobileOnly) {
-                return (
-                    isMobile ||
-                    (geoObjectsEnabled && el.elementName === 'pan')
-                )
-            }
-            return true
-        })
-        // Geo tools (point/area/route) appear alongside the shape tools only
-        // when the consumer opts in via the geoObjectsEnabled Board prop.
-        .concat(geoObjectsEnabled ? geoElementData : [])
+    const allElements = (() => {
+        const list = (
+            isMobile ? allElementsRaw : flattenShapesForDesktop(allElementsRaw)
+        )
+            .filter((el) => {
+                // Pan is normally mobile-only; surface it on desktop too when
+                // geo objects are enabled so the default tool is reachable.
+                if (el.mobileOnly) {
+                    return (
+                        isMobile ||
+                        (geoObjectsEnabled && el.elementName === 'pan')
+                    )
+                }
+                return true
+            })
+            // Whiteboard shape tools are hidden in geo mode in favour of the
+            // geo toolset (point/area/route/geoText).
+            .filter(
+                (el) =>
+                    !geoObjectsEnabled || !GEO_HIDDEN_TOOLS.has(el.elementName)
+            )
+            // Geo tools (point/area/route/geoText) appear alongside the shape
+            // tools only when the consumer opts in via the geoObjectsEnabled
+            // Board prop.
+            .concat(geoObjectsEnabled ? geoElementData : [])
+
+        // The eraser (rubber) always sits last in the toolbar order, after any
+        // geo tools appended above.
+        const rubberIdx = list.findIndex((el) => el.elementName === 'rubber')
+        if (rubberIdx !== -1) {
+            const [rubber] = list.splice(rubberIdx, 1)
+            list.push(rubber!)
+        }
+        return list
+    })()
 
     useEffect(() => {
         // Pan needs activating (addElement) to become the live mode; pointer is

--- a/src/components/sidebar/shapesToolbar.tsx
+++ b/src/components/sidebar/shapesToolbar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { ReactElement } from 'react'
 import {
     staticPrimaryElementData,
+    geoElementData,
     type PrimaryElement,
 } from '../../utils/constants'
 import { useBoardContext } from '../../views/Board/board'
@@ -47,6 +48,7 @@ const ShapesToolbar = ({ addElement }: ShapesToolbarProps): ReactElement => {
         redoLastAction,
         historyLog,
         bucketLog,
+        geoObjectsEnabled,
     } = useBoardContext()
     const { isMobile } = useMediaQueryUtils()
     const [openDrawer, setOpenDrawer] = useState<string | null>(null)
@@ -55,7 +57,11 @@ const ShapesToolbar = ({ addElement }: ShapesToolbarProps): ReactElement => {
 
     const allElements = (
         isMobile ? allElementsRaw : flattenShapesForDesktop(allElementsRaw)
-    ).filter((el) => (isMobile ? true : !el.mobileOnly))
+    )
+        .filter((el) => (isMobile ? true : !el.mobileOnly))
+        // Geo tools (point/area/route) appear alongside the shape tools only
+        // when the consumer opts in via the geoObjectsEnabled Board prop.
+        .concat(geoObjectsEnabled ? geoElementData : [])
 
     useEffect(() => {
         setCurrentElementInBoard('pointer')

--- a/src/components/sidebar/shapesToolbar.tsx
+++ b/src/components/sidebar/shapesToolbar.tsx
@@ -5,10 +5,15 @@ import {
     geoElementData,
     type PrimaryElement,
 } from '../../utils/constants'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 import UndoIcon from '../../assets/undo_amber.svg?react'
 import RedoIcon from '../../assets/redo.svg?react'
 import { useMediaQueryUtils } from '../../constants/exportHooks'
+import {
+    POINT_CATEGORIES,
+    DEFAULT_POINT_CATEGORY,
+    sizedCategoryIcon,
+} from '../../constants/misc'
 
 const allElementsRaw = staticPrimaryElementData.flatMap(
     (section) => section.elements
@@ -31,7 +36,7 @@ const flattenShapesForDesktop = (
     )
 
 interface ShapesToolbarProps {
-    addElement: (label: string) => void
+    addElement: (label: string, category?: string) => void
 }
 
 interface DrawerAnchor {
@@ -49,22 +54,59 @@ const ShapesToolbar = ({ addElement }: ShapesToolbarProps): ReactElement => {
         historyLog,
         bucketLog,
         geoObjectsEnabled,
+        selectedComponent,
+        applyProperty,
     } = useBoardContext()
     const { isMobile } = useMediaQueryUtils()
     const [openDrawer, setOpenDrawer] = useState<string | null>(null)
     const [drawerAnchor, setDrawerAnchor] = useState<DrawerAnchor | null>(null)
     const drawerRef = useRef<HTMLDivElement | null>(null)
+    // Last category chosen for *new* points (so the drawer reflects the user's
+    // pick across placements). A selected point's own category takes priority
+    // when the drawer is opened with one focused.
+    const [pointCategory, setPointCategory] = useState<string>(
+        DEFAULT_POINT_CATEGORY
+    )
+
+    // When a point is selected, the same drawer recolors it in place (via
+    // applyProperty) instead of starting a new draw. Read its current category
+    // so the active chip reflects the selection.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const selectedElementData = (selectedComponent as any)?.group?.data
+        ?.elementData
+    const isPointSelected = selectedElementData?.componentType === 'point'
+    const activePointCategory = isPointSelected
+        ? (selectedElementData?.metadata?.category ?? DEFAULT_POINT_CATEGORY)
+        : pointCategory
+
+    // With geo objects enabled, pan is the default/home tool, but the pointer
+    // stays available so points can be selected (to edit category / tooltip);
+    // otherwise the usual pointer/select default.
+    const homeTool = geoObjectsEnabled ? 'pan' : 'pointer'
 
     const allElements = (
         isMobile ? allElementsRaw : flattenShapesForDesktop(allElementsRaw)
     )
-        .filter((el) => (isMobile ? true : !el.mobileOnly))
+        .filter((el) => {
+            // Pan is normally mobile-only; surface it on desktop too when geo
+            // objects are enabled so the default tool is reachable.
+            if (el.mobileOnly) {
+                return (
+                    isMobile ||
+                    (geoObjectsEnabled && el.elementName === 'pan')
+                )
+            }
+            return true
+        })
         // Geo tools (point/area/route) appear alongside the shape tools only
         // when the consumer opts in via the geoObjectsEnabled Board prop.
         .concat(geoObjectsEnabled ? geoElementData : [])
 
     useEffect(() => {
-        setCurrentElementInBoard('pointer')
+        // Pan needs activating (addElement) to become the live mode; pointer is
+        // the board's resting state, so a highlight is enough.
+        if (geoObjectsEnabled) addElement('pan')
+        setCurrentElementInBoard(homeTool)
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
@@ -151,6 +193,7 @@ const ShapesToolbar = ({ addElement }: ShapesToolbarProps): ReactElement => {
                     const Icon = element.elementIcon
                     const isActive =
                         currentElement === element.elementName ||
+                        openDrawer === element.elementName ||
                         (element.hasDrawer &&
                             element.drawerData.some(
                                 (d) => d.elementName === currentElement
@@ -171,7 +214,23 @@ const ShapesToolbar = ({ addElement }: ShapesToolbarProps): ReactElement => {
                                 }
                             `}
                             onClick={(e): void => {
-                                if (element.hasDrawer) {
+                                // Point opens a category drawer rather than
+                                // drawing immediately — the chosen category
+                                // seeds the new point (or recolors a selected
+                                // one). Don't touch currentElement here so a
+                                // focused point stays selected for re-skinning.
+                                if (element.elementName === 'point') {
+                                    const rect =
+                                        e.currentTarget.getBoundingClientRect()
+                                    setDrawerAnchor({
+                                        left: rect.left,
+                                        top: rect.bottom,
+                                        rectTop: rect.top,
+                                    })
+                                    setOpenDrawer(
+                                        openDrawer === 'point' ? null : 'point'
+                                    )
+                                } else if (element.hasDrawer) {
                                     const rect =
                                         e.currentTarget.getBoundingClientRect()
                                     setDrawerAnchor({
@@ -188,7 +247,7 @@ const ShapesToolbar = ({ addElement }: ShapesToolbarProps): ReactElement => {
                                     )
                                     setCurrentElementInBoard(
                                         isToggleClose
-                                            ? 'pointer'
+                                            ? homeTool
                                             : element.elementName
                                     )
                                 } else {
@@ -266,6 +325,77 @@ const ShapesToolbar = ({ addElement }: ShapesToolbarProps): ReactElement => {
                                     aria-label={item.elementDisplayName}
                                 />
                             </div>
+                        )
+                    })}
+                </div>
+            )}
+
+            {/* Point categories — a swatch row beneath the toolbar. Picking one
+                seeds the next placed point, or recolors the focused point. */}
+            {openDrawer === 'point' && drawerAnchor && (
+                <div
+                    className={`fixed bg-sidebar shadow-card rounded-card flex items-center flex-row
+                        ${isMobile ? 'px-1 py-1 gap-1 border-b-4 border-accent-dark' : 'px-2 py-1 gap-1.5 border-t-4 border-accent-dark'}`}
+                    style={
+                        isMobile
+                            ? {
+                                  bottom:
+                                      window.innerHeight -
+                                      drawerAnchor.rectTop +
+                                      6,
+                                  left: drawerAnchor.left,
+                                  zIndex: 11,
+                              }
+                            : {
+                                  top: drawerAnchor.top + 6,
+                                  left: drawerAnchor.left,
+                                  zIndex: 11,
+                              }
+                    }
+                >
+                    {Object.values(POINT_CATEGORIES).map((cat) => {
+                        const isActive = activePointCategory === cat.id
+                        return (
+                            <button
+                                key={cat.id}
+                                title={cat.label}
+                                aria-label={cat.label}
+                                className={`${btnSize} flex items-center justify-center rounded-lg cursor-pointer transition-transform duration-150 hover:scale-105 ${
+                                    isActive ? 'scale-105' : ''
+                                }`}
+                                style={{
+                                    background: cat.bg,
+                                    border: cat.border
+                                        ? `2px solid ${cat.border}`
+                                        : 'none',
+                                    boxShadow: isActive
+                                        ? '0 0 0 2px #E8C87A'
+                                        : '2px 2px 0 #C4B89A',
+                                }}
+                                onClick={(): void => {
+                                    if (isPointSelected) {
+                                        // Recolor the focused point in place.
+                                        applyProperty?.('pointCategory', cat.id)
+                                    } else {
+                                        // Seed + arm a fresh point placement.
+                                        setPointCategory(cat.id)
+                                        addElement('point', cat.id)
+                                        setCurrentElementInBoard('point')
+                                    }
+                                    setOpenDrawer(null)
+                                }}
+                            >
+                                <span
+                                    className="flex items-center justify-center pointer-events-none"
+                                    // Category icons are pre-colored SVG strings.
+                                    dangerouslySetInnerHTML={{
+                                        __html: sizedCategoryIcon(
+                                            cat.svgIcon,
+                                            isMobile ? 16 : 18
+                                        ),
+                                    }}
+                                />
+                            </button>
                         )
                     })}
                 </div>

--- a/src/components/sidebar/shareLinkPopup.tsx
+++ b/src/components/sidebar/shareLinkPopup.tsx
@@ -6,7 +6,7 @@ import Button from '../common/button'
 import Modal from '../common/modal'
 import ShareIcon from '../../assets/share-android.svg'
 import CopyIcon from '../../assets/copy.svg'
-import { useBoardContext } from '../../views/Board/board'
+import { useBoardContext } from '../../views/Board/boardContext'
 import { UPDATE_BOARD_VISIBILITY } from '../../schema/mutations'
 
 const ShareLinkPopup = (): ReactElement => {

--- a/src/components/utils/colorPicker.tsx
+++ b/src/components/utils/colorPicker.tsx
@@ -7,6 +7,25 @@ import { MIXED } from '../../utils/groupInspect'
 const STORAGE_KEY = 'craftbase_saved_colors'
 const MAX_SAVED = 8
 
+// Checkerboard shown behind a transparent swatch so it reads as "no paint"
+// instead of rendering invisibly.
+const TRANSPARENT_SWATCH_BG =
+    'repeating-conic-gradient(#C4B89A 0% 25%, #F5F0E8 0% 50%) 0 0 / 8px 8px'
+
+// True for any rgba()/hsla() color with alpha 0.
+const isTransparentColor = (color?: string | null): boolean => {
+    if (!color) return false
+    const inner = /(?:rgba|hsla)\(([^)]+)\)/i.exec(color)?.[1]
+    if (!inner) return false
+    const parts = inner.split(',').map((s) => s.trim())
+    return parts.length === 4 && parseFloat(parts[3] ?? '1') === 0
+}
+
+// Background style for a swatch/preview: checkerboard for transparent,
+// the color itself otherwise, falling back to a transparent box.
+const swatchBackground = (color?: string | null): string =>
+    isTransparentColor(color) ? TRANSPARENT_SWATCH_BG : (color ?? 'transparent')
+
 const loadSavedColors = (): string[] => {
     try {
         const stored = localStorage.getItem(STORAGE_KEY)
@@ -30,6 +49,9 @@ export interface ColorPickerProps {
     currentColor?: string
     isExpanded?: boolean
     onToggleExpand?: () => void
+    // Quick-access swatch row. Defaults to the shared essentialShades; the
+    // Fill picker passes fillEssentialShades to surface a transparent option.
+    essentialColors?: string[]
 }
 
 const ColorPicker = ({
@@ -38,13 +60,16 @@ const ColorPicker = ({
     currentColor,
     isExpanded,
     onToggleExpand,
+    essentialColors = essentialShades,
 }: ColorPickerProps): ReactElement => {
     const [localExpanded, setLocalExpanded] = useState(false)
     const [savedColors, setSavedColors] = useState<string[]>(loadSavedColors)
     const [removingColor, setRemovingColor] = useState<string | null>(null)
     const isMixed = currentColor === MIXED
     const [hexInput, setHexInput] = useState(
-        isMixed ? '' : (currentColor?.replace(/^#/, '') ?? '')
+        isMixed || isTransparentColor(currentColor)
+            ? ''
+            : (currentColor?.replace(/^#/, '') ?? '')
     )
 
     // Support both controlled (isExpanded prop) and uncontrolled (local state) modes.
@@ -54,7 +79,7 @@ const ColorPicker = ({
         onToggleExpand ?? ((): void => setLocalExpanded((p) => !p))
 
     useEffect(() => {
-        if (currentColor === MIXED) {
+        if (currentColor === MIXED || isTransparentColor(currentColor)) {
             setHexInput('')
             return
         }
@@ -92,12 +117,16 @@ const ColorPicker = ({
     }
 
     const hasColor = !!currentColor && !isMixed
+    const isTransparent = isTransparentColor(currentColor)
     const mixedSwatchBg =
         'repeating-linear-gradient(45deg, #C4B89A 0 4px, #F5F0E8 4px 8px)'
 
     const swatchStyle = (color: string): CSSProperties => ({
-        background: color,
-        border: color === '#FFFFFF' ? '1.5px solid #1A1612' : 'none',
+        background: swatchBackground(color),
+        border:
+            color === '#FFFFFF' || isTransparentColor(color)
+                ? '1.5px solid #1A1612'
+                : 'none',
         outline: currentColor === color ? '2px solid #C48B0A' : 'none',
         outlineOffset: '1.5px',
     })
@@ -123,11 +152,13 @@ const ColorPicker = ({
                         style={{
                             background: isMixed
                                 ? mixedSwatchBg
-                                : hasColor
-                                  ? currentColor
-                                  : 'transparent',
+                                : isTransparent
+                                  ? TRANSPARENT_SWATCH_BG
+                                  : hasColor
+                                    ? currentColor
+                                    : 'transparent',
                             border:
-                                hasColor || isMixed
+                                (hasColor && !isTransparent) || isMixed
                                     ? 'none'
                                     : '1.5px solid #1A1612',
                         }}
@@ -135,9 +166,11 @@ const ColorPicker = ({
                     <span className="font-mono">
                         {isMixed
                             ? 'Mixed'
-                            : hasColor
-                              ? currentColor.toUpperCase()
-                              : 'None'}
+                            : isTransparent
+                              ? 'Transparent'
+                              : hasColor
+                                ? currentColor.toUpperCase()
+                                : 'None'}
                     </span>
                     <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
                         <path
@@ -169,7 +202,7 @@ const ColorPicker = ({
                                     style={{
                                         background: isMixed
                                             ? mixedSwatchBg
-                                            : (currentColor ?? 'transparent'),
+                                            : swatchBackground(currentColor),
                                         border: '2px solid #C48B0A',
                                     }}
                                 />
@@ -180,8 +213,10 @@ const ColorPicker = ({
                                     <div className="text-[11px] font-semibold text-[#1A1612] font-mono truncate">
                                         {isMixed
                                             ? 'Mixed'
-                                            : (currentColor?.toUpperCase() ??
-                                              '—')}
+                                            : isTransparent
+                                              ? 'Transparent'
+                                              : (currentColor?.toUpperCase() ??
+                                                '—')}
                                     </div>
                                 </div>
                                 <button
@@ -298,8 +333,9 @@ const ColorPicker = ({
                                 <div
                                     className="w-5 h-5 rounded-[4px] flex-shrink-0 border border-[#C4B89A]"
                                     style={{
-                                        background:
-                                            currentColor ?? 'transparent',
+                                        background: swatchBackground(
+                                            currentColor
+                                        ),
                                     }}
                                 />
                                 <div className="flex-1 flex items-center bg-[#FFFCF5] border border-[#C4B89A] rounded-[5px] px-2 py-1 gap-1">
@@ -335,16 +371,18 @@ const ColorPicker = ({
             </AnimatePresence>
 
             <div className="flex items-center gap-1">
-                {essentialShades.map((color) => (
+                {essentialColors.map((color) => (
                     <button
                         key={color}
                         onClick={(): void => handleColorSelect(color)}
-                        title={color}
+                        title={
+                            isTransparentColor(color) ? 'Transparent' : color
+                        }
                         className="mr-1 w-5 h-5 rounded-full flex-shrink-0 transition-transform hover:scale-110"
                         style={{
-                            background: color,
+                            background: swatchBackground(color),
                             border:
-                                color === '#FFFFFF'
+                                color === '#FFFFFF' || isTransparentColor(color)
                                     ? '1.5px solid #1A1612'
                                     : 'none',
                             outline:

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -9,7 +9,25 @@ export const componentTypes = {
     rectangle: 'rectangle',
     diamond: 'diamond',
     circle: 'circle',
+    point: 'point',
+    area: 'area',
+    route: 'route',
 } as const
+
+// Geo objects (point/area/route) ride the same components_component pipeline as
+// shapes — they're just a distinct category surfaced when a consumer opts in.
+export const geoObjectTypes = {
+    point: 'point',
+    area: 'area',
+    route: 'route',
+} as const
+
+export type GeoObjectType = keyof typeof geoObjectTypes
+
+export const isGeoType = (type: string | null | undefined): boolean =>
+    type === geoObjectTypes.point ||
+    type === geoObjectTypes.area ||
+    type === geoObjectTypes.route
 
 // Draw mode localStorage keys
 export const ARROW_DRAW_MODE_KEY = 'arrowDrawMode'
@@ -19,6 +37,41 @@ export const PENDING_SHAPE_PROPS_KEY = 'pendingShapeProps'
 export const LAST_ADDED_ELEMENT_ID_KEY = 'lastAddedElementId'
 export const PENCIL_MODE_KEY = 'pencilMode'
 export const PAN_MODE_KEY = 'panMode'
+
+// Geo draw modes. AREA/ROUTE use multi-click vertex placement; POINT is a
+// single click-to-place. The active geo type is stashed alongside the flag.
+export const GEO_DRAW_MODE_KEY = 'geoDrawMode'
+export const GEO_DRAW_TYPE_KEY = 'geoDrawType'
+export const GEO_DRAW_PROPS_KEY = 'geoDrawProps'
+export const GEO_POINT_PLACE_MODE_KEY = 'geoPointPlaceMode'
+
+// Pin/point counter-scale: 1/scale^resist keeps the pin legible when zoomed
+// out (0 = fully fixed on screen, 1 = scales with the world).
+export const DEFAULT_GEO_RESIST = 0.9
+export const DEFAULT_GEO_RING_RADIUS = 22
+
+// Default "pin" icon embedded inside a point. Consumers can override per-point
+// via metadata.svgIcon. currentColor lets the point recolor it to its stroke.
+export const DEFAULT_PIN_SVG =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z" fill="currentColor"/></svg>'
+
+// Per-type initial defaults for new geo objects (distinct, map-appropriate
+// colors from the prototypes). Users recolor afterward via the properties
+// toolbar. Kept client-side so geo creation doesn't depend on a DB round-trip.
+export const GEO_TYPE_DEFAULTS: Record<
+    GeoObjectType,
+    { stroke: string; linewidth: number }
+> = {
+    point: { stroke: '#C4501A', linewidth: 3 },
+    area: { stroke: '#A32D2D', linewidth: 2 },
+    route: { stroke: '#3B82F6', linewidth: 3 },
+}
+
+// Minimum vertices required to finish a multi-click geo draw.
+export const GEO_MIN_VERTICES: Record<'area' | 'route', number> = {
+    area: 3,
+    route: 2,
+}
 
 // Default colors
 export const PENCIL_DEFAULT_COLOR = '#3A342C'

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -55,6 +55,101 @@ export const DEFAULT_GEO_RING_RADIUS = 22
 export const DEFAULT_PIN_SVG =
     '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5S10.62 6.5 12 6.5s2.5 1.12 2.5 2.5S13.38 11.5 12 11.5z" fill="currentColor"/></svg>'
 
+// Point categories. A point's `metadata.category` drives its look: a filled
+// rounded-square pin in `bg`, a white (or dark, for ghost) icon, and a hard
+// offset shadow — see PointFactory.buildPointVisual. Icon colors are baked into
+// each svgIcon so the factory interprets them as-is (no recolor). Built into
+// craftbase behind `geoObjectsEnabled` (mirroring GEO_TYPE_DEFAULTS); a consumer
+// can override the catalog via the `pointCategories` Board prop.
+//
+// IMPORTANT: svgIcon path data must avoid SVG arc commands (`a`/`A`). Two.js's
+// `interpret()` (used to render the pin on the board) parses numbers with a
+// generic regex that can't split packed arc flags (e.g. `a6 6 0 0012 0` reads
+// `0012` as one number), producing NaN vertices and a blank icon. The browser
+// renders arcs fine — so the toolbar chip looks right while the board pin is
+// empty. Stick to M/L/C/Q/Z paths plus <line>/<circle>/<rect>/<polygon>.
+export interface PointCategory {
+    id: string
+    label: string
+    /** Pin background (the category color). */
+    bg: string
+    /** Icon tint baked into svgIcon — for the legend/picker chip. */
+    icon: string
+    /** Optional outline — only the light "ghost" pin uses it. */
+    border?: string
+    /** 24x24-viewBox icon with colors already baked in. */
+    svgIcon: string
+}
+
+export const POINT_CATEGORIES: Record<string, PointCategory> = {
+    generic: {
+        id: 'generic',
+        label: 'Generic',
+        bg: '#6B6560',
+        icon: '#FFFFFF',
+        svgIcon:
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="10" r="3.5" fill="#FFFFFF"/><path d="M12 4C8.69 4 6 6.69 6 10c0 5 6 10 6 10s6-5 6-10c0-3.31-2.69-6-6-6z" fill="none" stroke="#FFFFFF" stroke-width="1.6" stroke-linejoin="round"/></svg>',
+    },
+    fire: {
+        id: 'fire',
+        label: 'Fire',
+        bg: '#E8621A',
+        icon: '#FFFFFF',
+        svgIcon:
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 3C10 7 7.5 9 7.5 13.5C7.5 17 9.5 19.5 12 19.5C14.5 19.5 16.5 17 16.5 13.5C16.5 9 14 7 12 3Z" fill="#FFFFFF"/><path d="M12 11C11 12.2 10.4 13.2 10.4 14.3C10.4 15.6 11.1 16.4 12 16.4C12.9 16.4 13.6 15.6 13.6 14.3C13.6 13.2 13 12.2 12 11Z" fill="#E8621A"/></svg>',
+    },
+    water: {
+        id: 'water',
+        label: 'Water',
+        bg: '#2A8BC8',
+        icon: '#FFFFFF',
+        svgIcon:
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 3C10 7 7 11 7 15C7 17.8 9.2 20 12 20C14.8 20 17 17.8 17 15C17 11 14 7 12 3Z" fill="#FFFFFF"/></svg>',
+    },
+    nature: {
+        id: 'nature',
+        label: 'Nature',
+        bg: '#4A9A5A',
+        icon: '#FFFFFF',
+        svgIcon:
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 3L8.5 8.5L10.5 8.5L7 12.5L9.5 12.5L6 16.5L18 16.5L14.5 12.5L17 12.5L13.5 8.5L15.5 8.5Z" fill="#FFFFFF"/><line x1="12" y1="16" x2="12" y2="20.5" stroke="#FFFFFF" stroke-width="2.2" stroke-linecap="round"/></svg>',
+    },
+    alert: {
+        id: 'alert',
+        label: 'Alert',
+        bg: '#D03030',
+        icon: '#FFFFFF',
+        svgIcon:
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 5L3 19h18L12 5z" fill="none" stroke="#FFFFFF" stroke-width="1.8" stroke-linejoin="round"/><line x1="12" y1="10" x2="12" y2="14" stroke="#FFFFFF" stroke-width="1.8" stroke-linecap="round"/><circle cx="12" cy="17" r="1" fill="#FFFFFF"/></svg>',
+    },
+    infra: {
+        id: 'infra',
+        label: 'Infra',
+        bg: '#1A1612',
+        icon: '#FFFFFF',
+        svgIcon:
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><line x1="12" y1="4" x2="6" y2="20" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round"/><line x1="12" y1="4" x2="18" y2="20" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round"/><line x1="8" y1="11" x2="16" y2="11" stroke="#FFFFFF" stroke-width="1.4" stroke-linecap="round"/><line x1="7" y1="15.5" x2="17" y2="15.5" stroke="#FFFFFF" stroke-width="1.4" stroke-linecap="round"/><line x1="12" y1="2" x2="12" y2="5" stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round"/><line x1="9" y1="5.5" x2="15" y2="5.5" stroke="#FFFFFF" stroke-width="1.4" stroke-linecap="round"/></svg>',
+    },
+    ghost: {
+        id: 'ghost',
+        label: 'Ghost',
+        bg: '#FFFCF5',
+        icon: '#1A1612',
+        border: '#C4B89A',
+        svgIcon:
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3" fill="#1A1612"/><circle cx="12" cy="12" r="6" fill="none" stroke="#C4901A" stroke-width="1.5"/></svg>',
+    },
+}
+
+export const DEFAULT_POINT_CATEGORY = 'generic'
+
+// The catalog svgs carry only a viewBox (so Two.js can scale them freely). For
+// HTML rendering (the category picker chip, the tooltip mini-pin) inject an
+// explicit pixel size so they render at a known size regardless of CSS/purge.
+export function sizedCategoryIcon(svg: string, px: number): string {
+    return svg.replace('<svg ', `<svg width="${px}" height="${px}" `)
+}
+
 // Per-type initial defaults for new geo objects (distinct, map-appropriate
 // colors from the prototypes). Users recolor afterward via the properties
 // toolbar. Kept client-side so geo creation doesn't depend on a DB round-trip.

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -29,6 +29,15 @@ export const isGeoType = (type: string | null | undefined): boolean =>
     type === geoObjectTypes.area ||
     type === geoObjectTypes.route
 
+// Standalone text element types: 'newText' (whiteboard) and 'geoText' (the
+// zoom-resistant map variant). They render identically and share every text
+// code path (properties toolbar, group apply, history revert, clipboard) — the
+// only difference is geoText's per-frame counter-scale. Use this everywhere a
+// "is this standalone text?" decision is made so both stay in lockstep.
+export const isStandaloneTextType = (
+    type: string | null | undefined
+): boolean => type === 'newText' || type === 'geoText'
+
 // Draw mode localStorage keys
 export const ARROW_DRAW_MODE_KEY = 'arrowDrawMode'
 export const TEXT_DRAW_MODE_KEY = 'textDrawMode'

--- a/src/factory/area.ts
+++ b/src/factory/area.ts
@@ -1,0 +1,53 @@
+import Main from './main'
+import Two from 'two.js'
+import { strokeTypeToDashes, strokeToAreaFill } from '../utils/misc'
+
+export interface GeoVertex {
+    x: number
+    y: number
+}
+
+export interface AreaProperties {
+    stroke?: string
+    linewidth?: number
+    strokeType?: string | null
+    // Absolute vertex coords (same convention as pencil); the factory makes
+    // them relative to the group origin (x, y).
+    metadata: GeoVertex[]
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ShapeLike = any
+
+export default class AreaFactory extends Main<AreaProperties> {
+    path?: ShapeLike
+    group?: ShapeLike
+
+    createElement(): { group: ShapeLike; path: ShapeLike } {
+        const two = this.two
+        const prevX = this.x
+        const prevY = this.y
+        const { stroke, linewidth, strokeType, metadata } = this.properties
+
+        const vertices = Array.isArray(metadata) ? metadata : []
+        const anchors = vertices.map(
+            (p) => new (Two as ShapeLike).Anchor(p.x - prevX, p.y - prevY)
+        )
+
+        // closed = true → filled polygon (area)
+        const path = new (Two as ShapeLike).Path(anchors, true, false)
+        const strokeColor = stroke || '#A32D2D'
+        path.stroke = strokeColor
+        // Fill is always derived from stroke @ 0.7 — never persisted.
+        path.fill = strokeToAreaFill(strokeColor)
+        path.linewidth = linewidth ? linewidth : 2
+        path.dashes = strokeTypeToDashes(strokeType)
+
+        this.path = path
+        const group = two.makeGroup(path)
+        group.translation.x = parseInt(String(prevX))
+        group.translation.y = parseInt(String(prevY))
+        this.group = group
+        return { group: this.group, path }
+    }
+}

--- a/src/factory/geoText.ts
+++ b/src/factory/geoText.ts
@@ -1,0 +1,8 @@
+// geoText renders identically to newText — it's the same Two.js text group; the
+// only difference lives in the component (geoText.tsx counter-scales the group
+// on zoom). Re-export NewTextFactory so the componentType→factory lookups
+// (group reconstruction in groupobject.tsx, etc.) resolve `geoText` to the same
+// builder without duplicating the rendering code.
+import NewTextFactory from './newText'
+
+export default NewTextFactory

--- a/src/factory/point.ts
+++ b/src/factory/point.ts
@@ -1,14 +1,15 @@
 import Main from './main'
 import Two from 'two.js'
 import {
-    DEFAULT_PIN_SVG,
     DEFAULT_GEO_RING_RADIUS,
+    POINT_CATEGORIES,
+    DEFAULT_POINT_CATEGORY,
 } from '../constants/misc'
-import { TRANSPARENT_FILL } from '../utils/constants'
 
 export interface PointProperties {
     stroke?: string
     metadata?: {
+        category?: string
         svgIcon?: string
         resist?: number
         ringRadius?: number
@@ -18,7 +19,7 @@ export interface PointProperties {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ShapeLike = any
 
-// Read viewBox so we can center the interpreted icon inside the ring. Defaults
+// Read viewBox so we can center the interpreted icon inside the pin. Defaults
 // to a 24x24 box (the standard icon viewport) when absent.
 function parseViewBox(svg: string): { x: number; y: number; w: number; h: number } {
     const m = /viewBox\s*=\s*["']([^"']+)["']/i.exec(svg)
@@ -31,76 +32,80 @@ function parseViewBox(svg: string): { x: number; y: number; w: number; h: number
     return { x: 0, y: 0, w: 24, h: 24 }
 }
 
-// Recolor only the icon paths that have no meaningful color of their own
-// (the default pin uses fill="currentColor"). User-supplied SVGs with explicit
-// colors are left untouched.
-function recolorIcon(node: ShapeLike, color: string): void {
-    if (!node) return
-    if (Array.isArray(node.children) && node.children.length) {
-        node.children.forEach((c: ShapeLike) => recolorIcon(c, color))
-        return
+// (Re)build a point's filled-square pin into `group`, in place. Clears any prior
+// children so it can also re-skin an existing point when its category changes
+// (see applyPointCategory). The pin is a hard-shadowed rounded square in the
+// category color with a white (or dark, for ghost) icon centered on top — the
+// whole group is counter-scaled by the caller so it stays legible on zoom-out.
+export function buildPointVisual(
+    two: ShapeLike,
+    group: ShapeLike,
+    opts: { category?: string; ringRadius?: number }
+): void {
+    const category = opts.category || DEFAULT_POINT_CATEGORY
+    const cat = POINT_CATEGORIES[category] || POINT_CATEGORIES[DEFAULT_POINT_CATEGORY]!
+    const ringRadius = opts.ringRadius ?? DEFAULT_GEO_RING_RADIUS
+
+    // Clear existing children (snapshot first — the collection mutates as we go).
+    const existing: ShapeLike[] = [...(group.children || [])]
+    existing.forEach((child) => group.remove(child))
+
+    const size = ringRadius * 2
+    const corner = size * 0.26 // matches the HTML's ~11px radius on a 42px pin
+
+    // Hard offset shadow (behind everything).
+    const shadow = new (Two as ShapeLike).RoundedRectangle(3, 3, size, size, corner)
+    shadow.fill = '#C4B89A'
+    shadow.noStroke()
+    group.add(shadow)
+
+    // Filled background — the category color. Opaque, so it's the click target.
+    const bg = new (Two as ShapeLike).RoundedRectangle(0, 0, size, size, corner)
+    bg.fill = cat.bg
+    if (cat.border) {
+        bg.stroke = cat.border
+        bg.linewidth = 2
+    } else {
+        bg.noStroke()
     }
-    const f = node.fill
-    if (
-        f === undefined ||
-        f === null ||
-        f === 'none' ||
-        String(f).toLowerCase() === 'currentcolor'
-    ) {
-        node.fill = color
+    group.add(bg)
+
+    // Icon — colors are baked into the catalog svg, so interpret as-is.
+    try {
+        const doc = new DOMParser().parseFromString(cat.svgIcon, 'image/svg+xml')
+        const svgNode = doc.documentElement as unknown as SVGElement
+        const icon = two.interpret(svgNode, false, false)
+        if (icon) {
+            const vb = parseViewBox(cat.svgIcon)
+            const s = (ringRadius * 0.95) / Math.max(vb.w, vb.h)
+            icon.scale = s
+            icon.translation.set(
+                -(vb.x + vb.w / 2) * s,
+                -(vb.y + vb.h / 2) * s
+            )
+            group.add(icon)
+        }
+    } catch {
+        // Bad SVG → keep the colored square (still a usable pin).
     }
 }
 
 export default class PointFactory extends Main<PointProperties> {
-    ring?: ShapeLike
     group?: ShapeLike
 
-    createElement(): { group: ShapeLike; ring: ShapeLike } {
+    createElement(): { group: ShapeLike } {
         const two = this.two
-        const prevX = this.x
-        const prevY = this.y
-        const { stroke } = this.properties
         const meta = this.properties.metadata || {}
-        const ringRadius = meta.ringRadius ?? DEFAULT_GEO_RING_RADIUS
-        const strokeColor = stroke || '#3A342C'
-
         const group = two.makeGroup()
 
-        // Outer ring — transparent fill keeps the disc clickable.
-        const ring = new (Two as ShapeLike).Circle(0, 0, ringRadius)
-        ring.fill = TRANSPARENT_FILL
-        ring.stroke = strokeColor
-        ring.linewidth = 3
-        group.add(ring)
-        this.ring = ring
+        buildPointVisual(two, group, {
+            category: meta.category,
+            ringRadius: meta.ringRadius,
+        })
 
-        // Embedded SVG icon (default "pin", overridable via metadata.svgIcon).
-        const svgString = meta.svgIcon || DEFAULT_PIN_SVG
-        try {
-            const doc = new DOMParser().parseFromString(
-                svgString,
-                'image/svg+xml'
-            )
-            const svgNode = doc.documentElement as unknown as SVGElement
-            const icon = two.interpret(svgNode, false, false)
-            if (icon) {
-                recolorIcon(icon, strokeColor)
-                const vb = parseViewBox(svgString)
-                const s = (ringRadius * 1.4) / Math.max(vb.w, vb.h)
-                icon.scale = s
-                icon.translation.set(
-                    -(vb.x + vb.w / 2) * s,
-                    -(vb.y + vb.h / 2) * s
-                )
-                group.add(icon)
-            }
-        } catch {
-            // Bad SVG → keep the ring only.
-        }
-
-        group.translation.x = parseInt(String(prevX))
-        group.translation.y = parseInt(String(prevY))
+        group.translation.x = parseInt(String(this.x))
+        group.translation.y = parseInt(String(this.y))
         this.group = group
-        return { group: this.group, ring: this.ring }
+        return { group: this.group }
     }
 }

--- a/src/factory/point.ts
+++ b/src/factory/point.ts
@@ -1,0 +1,106 @@
+import Main from './main'
+import Two from 'two.js'
+import {
+    DEFAULT_PIN_SVG,
+    DEFAULT_GEO_RING_RADIUS,
+} from '../constants/misc'
+import { TRANSPARENT_FILL } from '../utils/constants'
+
+export interface PointProperties {
+    stroke?: string
+    metadata?: {
+        svgIcon?: string
+        resist?: number
+        ringRadius?: number
+    } | null
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ShapeLike = any
+
+// Read viewBox so we can center the interpreted icon inside the ring. Defaults
+// to a 24x24 box (the standard icon viewport) when absent.
+function parseViewBox(svg: string): { x: number; y: number; w: number; h: number } {
+    const m = /viewBox\s*=\s*["']([^"']+)["']/i.exec(svg)
+    if (m && m[1]) {
+        const p = m[1].split(/[\s,]+/).map(Number)
+        if (p.length === 4 && p.every((n) => Number.isFinite(n))) {
+            return { x: p[0]!, y: p[1]!, w: p[2]!, h: p[3]! }
+        }
+    }
+    return { x: 0, y: 0, w: 24, h: 24 }
+}
+
+// Recolor only the icon paths that have no meaningful color of their own
+// (the default pin uses fill="currentColor"). User-supplied SVGs with explicit
+// colors are left untouched.
+function recolorIcon(node: ShapeLike, color: string): void {
+    if (!node) return
+    if (Array.isArray(node.children) && node.children.length) {
+        node.children.forEach((c: ShapeLike) => recolorIcon(c, color))
+        return
+    }
+    const f = node.fill
+    if (
+        f === undefined ||
+        f === null ||
+        f === 'none' ||
+        String(f).toLowerCase() === 'currentcolor'
+    ) {
+        node.fill = color
+    }
+}
+
+export default class PointFactory extends Main<PointProperties> {
+    ring?: ShapeLike
+    group?: ShapeLike
+
+    createElement(): { group: ShapeLike; ring: ShapeLike } {
+        const two = this.two
+        const prevX = this.x
+        const prevY = this.y
+        const { stroke } = this.properties
+        const meta = this.properties.metadata || {}
+        const ringRadius = meta.ringRadius ?? DEFAULT_GEO_RING_RADIUS
+        const strokeColor = stroke || '#3A342C'
+
+        const group = two.makeGroup()
+
+        // Outer ring — transparent fill keeps the disc clickable.
+        const ring = new (Two as ShapeLike).Circle(0, 0, ringRadius)
+        ring.fill = TRANSPARENT_FILL
+        ring.stroke = strokeColor
+        ring.linewidth = 3
+        group.add(ring)
+        this.ring = ring
+
+        // Embedded SVG icon (default "pin", overridable via metadata.svgIcon).
+        const svgString = meta.svgIcon || DEFAULT_PIN_SVG
+        try {
+            const doc = new DOMParser().parseFromString(
+                svgString,
+                'image/svg+xml'
+            )
+            const svgNode = doc.documentElement as unknown as SVGElement
+            const icon = two.interpret(svgNode, false, false)
+            if (icon) {
+                recolorIcon(icon, strokeColor)
+                const vb = parseViewBox(svgString)
+                const s = (ringRadius * 1.4) / Math.max(vb.w, vb.h)
+                icon.scale = s
+                icon.translation.set(
+                    -(vb.x + vb.w / 2) * s,
+                    -(vb.y + vb.h / 2) * s
+                )
+                group.add(icon)
+            }
+        } catch {
+            // Bad SVG → keep the ring only.
+        }
+
+        group.translation.x = parseInt(String(prevX))
+        group.translation.y = parseInt(String(prevY))
+        this.group = group
+        return { group: this.group, ring: this.ring }
+    }
+}

--- a/src/factory/route.ts
+++ b/src/factory/route.ts
@@ -1,0 +1,49 @@
+import Main from './main'
+import Two from 'two.js'
+import { strokeTypeToDashes } from '../utils/misc'
+import type { GeoVertex } from './area'
+
+export interface RouteProperties {
+    stroke?: string
+    linewidth?: number
+    strokeType?: string | null
+    // Absolute vertex coords (same convention as pencil); the factory makes
+    // them relative to the group origin (x, y).
+    metadata: GeoVertex[]
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ShapeLike = any
+
+export default class RouteFactory extends Main<RouteProperties> {
+    path?: ShapeLike
+    group?: ShapeLike
+
+    createElement(): { group: ShapeLike; path: ShapeLike } {
+        const two = this.two
+        const prevX = this.x
+        const prevY = this.y
+        const { stroke, linewidth, strokeType, metadata } = this.properties
+
+        const vertices = Array.isArray(metadata) ? metadata : []
+        const anchors = vertices.map(
+            (p) => new (Two as ShapeLike).Anchor(p.x - prevX, p.y - prevY)
+        )
+
+        // closed = false → open polyline (route)
+        const path = new (Two as ShapeLike).Path(anchors, false, false)
+        path.noFill()
+        path.stroke = stroke || '#3B82F6'
+        path.linewidth = linewidth ? linewidth : 2.5
+        path.cap = 'round'
+        path.join = 'round'
+        path.dashes = strokeTypeToDashes(strokeType)
+
+        this.path = path
+        const group = two.makeGroup(path)
+        group.translation.x = parseInt(String(prevX))
+        group.translation.y = parseInt(String(prevY))
+        this.group = group
+        return { group: this.group, path }
+    }
+}

--- a/src/hooks/useCanvasClipboard.ts
+++ b/src/hooks/useCanvasClipboard.ts
@@ -216,7 +216,9 @@ export function useCanvasClipboard({
                     newItem.y2 = dy
                 }
                 if (
-                    src.componentType === 'pencil' &&
+                    (src.componentType === 'pencil' ||
+                        src.componentType === 'area' ||
+                        src.componentType === 'route') &&
                     Array.isArray(src.metadata)
                 ) {
                     const dx = px - src.x

--- a/src/hooks/useCanvasClipboard.ts
+++ b/src/hooks/useCanvasClipboard.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import type { MutableRefObject } from 'react'
-import { GROUP_COMPONENT } from '../constants/misc'
+import { GROUP_COMPONENT, isStandaloneTextType } from '../constants/misc'
 import { generateUUID } from '../utils/misc'
 import { cloneElementData, getShapeTextNodes } from '../utils/canvasUtils'
 import type { ComponentRecord } from '../types/board'
@@ -129,7 +129,7 @@ export function useCanvasClipboard({
                         item.y2 = parseInt(String(line.vertices[1].y))
                     }
                 }
-                if (elementData.componentType === 'newText') {
+                if (isStandaloneTextType(elementData.componentType)) {
                     // Multiline standalone text is a stack of Two.Text line
                     // nodes (line 1 + satellites) in the same group;
                     // children[0] alone is only line 1. Reconstruct the raw

--- a/src/hooks/useComponentHistory.ts
+++ b/src/hooks/useComponentHistory.ts
@@ -11,7 +11,7 @@ import {
     applyShapeText,
 } from '../utils/canvasUtils'
 import { lineHeightFor } from '../utils/textLayout'
-import { DRAFT_STORAGE_KEY } from '../constants/misc'
+import { DRAFT_STORAGE_KEY, isStandaloneTextType } from '../constants/misc'
 import type { ComponentRecord, ComponentStore } from '../types/board'
 
 // Two.js scene-group shapes are typed loosely until the canvas internals
@@ -124,8 +124,9 @@ function applyPropertyToTwoJSGroup(
     // line nodes — text props must hit EVERY node, not just children[0].
     // Empty for non-text shapes, so this stays a no-op there.
     const textNodes: ShapeLike[] = getShapeTextNodes(group)
-    const isStandaloneText =
-        group.elementData?.componentType === 'newText'
+    const isStandaloneText = isStandaloneTextType(
+        group.elementData?.componentType
+    )
 
     switch (name) {
         case 'fill':
@@ -368,9 +369,9 @@ export function useComponentHistory({
         const m = meta as Record<string, any>
         const ct = group.elementData?.componentType
 
-        if (ct === 'newText') {
+        if (isStandaloneTextType(ct)) {
             // Standalone multiline text is a stack of Two.Text nodes owned by
-            // the newText component (extraLineNodesRef). Rebuilding them from
+            // the newText/geoText component (extraLineNodesRef). Rebuilding them from
             // here would desync that ref and orphan nodes on the next edit, so
             // let the component re-stack through its own path instead.
             if (typeof m.content !== 'string') return

--- a/src/hooks/useDrawingModes.ts
+++ b/src/hooks/useDrawingModes.ts
@@ -193,7 +193,9 @@ export function useDrawingModes(): DrawingModesApi {
         if (!root) return
         const active = isPencilMode || isArrowDrawMode || isRubberMode
         root.classList.toggle('draw-mode-active', active)
-    }, [isPencilMode, isArrowDrawMode, isRubberMode])
+        // Pan mode shows a grab cursor across the canvas (see common.css).
+        root.classList.toggle('pan-mode-active', isPanMode)
+    }, [isPencilMode, isArrowDrawMode, isRubberMode, isPanMode])
 
     const clearDrawModesFromStorage = (): void => {
         localStorage.removeItem(PENDING_SHAPE_TYPE_KEY)

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,7 +3,9 @@
 // src/index.js — this file is purely the public surface.
 
 export { default as Board } from './views/Board'
-export { BoardContext, useBoardContext } from './views/Board/board'
+// Context comes from the dedicated stable module (not board.tsx) so its identity
+// survives HMR — see boardContext.ts for the rationale.
+export { BoardContext, useBoardContext } from './views/Board/boardContext'
 
 export { useDrawingModes } from './hooks/useDrawingModes'
 export { useElementDefaults } from './hooks/useElementDefaults'
@@ -18,6 +20,12 @@ export { useCanvasClipboard } from './hooks/useCanvasClipboard'
 export { INSERT_USER_ONE } from './schema/mutations'
 export { generateRandomUsernames } from './utils/misc'
 
+// Point categories — the built-in 7-category catalog a consumer can read to
+// build its own legend/filters. The `category` lives in a point's
+// metadata.category and drives its pin look.
+export { POINT_CATEGORIES, DEFAULT_POINT_CATEGORY } from './constants/misc'
+export type { PointCategory } from './constants/misc'
+
 // Public type surface. Re-export from the canonical types module so consumers
 // can `import type { BoardProps, BoardContextValue, ComponentRecord } from 'craftbase'`.
 export type {
@@ -27,6 +35,8 @@ export type {
     ComponentStore,
     ComponentMetadata,
     CameraChangeEvent,
+    PointScreenInfo,
+    Cluster,
     SelectedComponent,
     SelectedGroup,
     CurrentElement,

--- a/src/newCanvas.tsx
+++ b/src/newCanvas.tsx
@@ -19,7 +19,7 @@ import React, {
 import Two from 'two.js'
 
 import { ZUI } from 'two.js/extras/jsm/zui'
-import { useBoardContext } from './views/Board/board'
+import { useBoardContext } from './views/Board/boardContext'
 import { useMediaQueryUtils } from './constants/exportHooks'
 
 import {
@@ -210,6 +210,12 @@ function addZUI(
     let isSinglePanning = false
     let panLastX = 0
     let panLastY = 0
+    // Desktop pan-mode: grab-and-drag with the mouse translates the surface
+    // (mirrors the single-finger touch pan above). Set on mousedown while pan
+    // mode is active, cleared on mouseup.
+    let isMousePanning = false
+    let mousePanLastX = 0
+    let mousePanLastY = 0
     let dragging = false
     let isResizeEvent = false
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -425,8 +431,10 @@ function addZUI(
             finalShapeData as unknown as ComponentRecord
         )
         setSelectedComponentInBoard(null)
-        setPointerElement('pointer')
+        // Reset cursor first: when geo is enabled setPointerElement re-activates
+        // pan, which sets its own 'grab' cursor that should win.
         setRootCursor('auto')
+        setPointerElement('pointer')
     }
 
     window.addEventListener('cancelGeoDraw', () => {
@@ -868,8 +876,9 @@ function addZUI(
     hoverCircle.opacity = 0
 
     function hoverDetectMove(e: MouseEvent) {
-        // No arrow-endpoint hover while drawing/placing a geo object.
+        // No arrow-endpoint hover while panning or drawing/placing a geo object.
         if (
+            isMousePanning ||
             geoDrawType ||
             localStorage.getItem(GEO_POINT_PLACE_MODE_KEY) === 'true'
         ) {
@@ -924,6 +933,22 @@ function addZUI(
     }
 
     function mousedown(e: MouseEvent) {
+        // Pan-mode (desktop): grab-and-drag translates the surface instead of
+        // selecting/drawing. Runs before everything else so a click on a shape
+        // pans rather than selecting it. Mirrors the single-finger touch pan.
+        if (isPanMode()) {
+            isMousePanning = true
+            mousePanLastX = e.clientX
+            mousePanLastY = e.clientY
+            const root = document.getElementById('main-two-root')
+            if (root) root.classList.add('panning')
+            // Drag on window so a release outside the canvas still ends the pan
+            // (and dragging keeps tracking past the canvas edge).
+            window.addEventListener('mousemove', mousemove, false)
+            window.addEventListener('mouseup', mouseup, false)
+            return
+        }
+
         // initialize shape definition
         const lastAddedElementId = localStorage.getItem(
             LAST_ADDED_ELEMENT_ID_KEY
@@ -1472,6 +1497,25 @@ function addZUI(
     }
 
     function mousemove(e: MouseEvent) {
+        // Pan-mode (desktop): translate the surface by the per-frame mouse
+        // delta. Mirrors the single-finger touch pan in touchmove.
+        if (isMousePanning) {
+            const dx = e.clientX - mousePanLastX
+            const dy = e.clientY - mousePanLastY
+            mousePanLastX = e.clientX
+            mousePanLastY = e.clientY
+            if (dx !== 0 || dy !== 0) {
+                zui.translateSurface(dx, dy)
+                two.update()
+                onCameraChangeRef?.current?.({
+                    scale: two.scene.scale,
+                    tx: two.scene.translation.x,
+                    ty: two.scene.translation.y,
+                })
+            }
+            return
+        }
+
         // Multi-click geo draw: rubber-band the preview line to the cursor.
         if (geoDrawType) {
             const s = toSurface(e)
@@ -1790,6 +1834,18 @@ function addZUI(
     }
 
     function mouseup(e: MouseEvent) {
+        // Pan-mode (desktop): end the grab-drag, restore the grab cursor and
+        // detach the on-demand listeners. Persist the viewport like the wheel.
+        if (isMousePanning) {
+            isMousePanning = false
+            const root = document.getElementById('main-two-root')
+            if (root) root.classList.remove('panning')
+            window.removeEventListener('mousemove', mousemove, false)
+            window.removeEventListener('mouseup', mouseup, false)
+            scheduleViewportSave()
+            return
+        }
+
         switch (scenario) {
             case SCENARIO_ARROW_DRAW: {
                 if (arrowDrawElement) {
@@ -2124,8 +2180,28 @@ function addZUI(
         domElement.removeEventListener('mouseup', mouseup, false)
     }
 
+    // Debounced persist of the current camera (pan + zoom) so a reload restores
+    // the viewport. Shared by the wheel and the desktop pan-drag.
+    function scheduleViewportSave() {
+        if (!props.boardId) return
+        if (viewportSaveTimer) clearTimeout(viewportSaveTimer)
+        viewportSaveTimer = setTimeout(() => {
+            localStorage.setItem(
+                `${VIEWPORT_KEY_PREFIX}${props.boardId}`,
+                JSON.stringify({
+                    tx: two.scene.translation.x,
+                    ty: two.scene.translation.y,
+                    scale: two.scene.scale,
+                    savedAt: Date.now(),
+                })
+            )
+        }, 300)
+    }
+
     function mousewheel(e: WheelEvent) {
-        if (e.shiftKey === true || e.metaKey === true) {
+        // Pan mode treats a plain wheel/scroll as zoom (no modifier needed);
+        // otherwise the wheel pans the surface and shift/meta zooms.
+        if (e.shiftKey === true || e.metaKey === true || isPanMode()) {
             let dy =
                 ((e as WheelEvent & { wheelDeltaY?: number }).wheelDeltaY ||
                     -e.deltaY) / 1000
@@ -2145,20 +2221,7 @@ function addZUI(
             ty: two.scene.translation.y,
         })
 
-        if (props.boardId) {
-            if (viewportSaveTimer) clearTimeout(viewportSaveTimer)
-            viewportSaveTimer = setTimeout(() => {
-                localStorage.setItem(
-                    `${VIEWPORT_KEY_PREFIX}${props.boardId}`,
-                    JSON.stringify({
-                        tx: two.scene.translation.x,
-                        ty: two.scene.translation.y,
-                        scale: two.scene.scale,
-                        savedAt: Date.now(),
-                    })
-                )
-            }, 300)
-        }
+        scheduleViewportSave()
     }
 
     // --- Touch handlers ---
@@ -2508,11 +2571,25 @@ const Canvas: React.FC<CanvasProps> = (props) => {
         setArrowDrawModeInBoard,
         setTextDrawModeInBoard,
         setCurrentElementInBoard,
+        togglePanMode,
+        geoObjectsEnabled,
         undoLastAction,
         redoLastAction,
         enableTextDrawMode,
         createTextAtSurface,
     } = useBoardContext()
+
+    // addZUI's post-draw resets funnel a 'pointer' through setPointerElement.
+    // With geo objects enabled the home tool is pan (pointer is hidden), so
+    // re-activate pan instead of stranding the user in hidden select mode.
+    const resetToHomeTool = (element: CurrentElement | null): void => {
+        if (element === 'pointer' && geoObjectsEnabled) {
+            togglePanMode(true)
+            setCurrentElementInBoard('pan')
+            return
+        }
+        setCurrentElementInBoard(element)
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [twoJSInstance, setTwoJSInstance] = useState<any>(null)
@@ -2578,7 +2655,7 @@ const Canvas: React.FC<CanvasProps> = (props) => {
             setSelectedComponentInBoard,
             () => setArrowDrawModeInBoard(false),
             () => setTextDrawModeInBoard(false),
-            setCurrentElementInBoard,
+            resetToHomeTool,
             updateComponentBulkPropertiesInLocalStore,
             deleteComponentFromLocalStore,
             isPencilModeRef,

--- a/src/newCanvas.tsx
+++ b/src/newCanvas.tsx
@@ -44,6 +44,11 @@ import {
     LINE_HEIGHT_MULTIPLIER,
     PENCIL_DISTANCE_THROTTLE,
     DEFAULT_TEXT_SIZE,
+    GEO_DRAW_MODE_KEY,
+    GEO_DRAW_TYPE_KEY,
+    GEO_DRAW_PROPS_KEY,
+    GEO_POINT_PLACE_MODE_KEY,
+    GEO_MIN_VERTICES,
 } from './constants/misc'
 import Spinner from './components/common/spinner'
 
@@ -69,10 +74,7 @@ import {
     applyShapeText,
     shapeTextStyleFromMeta,
 } from './utils/canvasUtils'
-import {
-    growShapeToFitText,
-    usableTextWidth,
-} from './utils/shapeTextFit'
+import { growShapeToFitText, usableTextWidth } from './utils/shapeTextFit'
 import { isSelectPanMode, isPanMode } from './utils/drawModeUtils'
 import { createDiamondPath } from './factory/diamond'
 import { useCanvasClipboard } from './hooks/useCanvasClipboard'
@@ -237,6 +239,8 @@ function addZUI(
     const SCENARIO_DRAW_SHAPE = 'drawShape'
     const SCENARIO_TEXT_DRAW = 'textDraw'
     const SCENARIO_RUBBER_MODE = 'rubberMode'
+    const SCENARIO_GEO_POINT = 'geoPoint'
+    const SCENARIO_GEO_DRAW = 'geoDraw'
     const SCENARIO_DEFAULT = null
 
     const pendingDeletionSet = new Set<string>()
@@ -263,6 +267,20 @@ function addZUI(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let pendingGroupSelectorOrigin: any = null
 
+    // ── Geo multi-click draw state (area / route) ────────────────────────────
+    // Vertices are surface coords; preview dots/lines live in two.scene so ZUI
+    // transforms them like everything else. Built into a component on finish.
+    let geoDrawType: 'area' | 'route' | null = null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let geoDrawProps: any = null
+    let geoVertices: { x: number; y: number }[] = []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let geoDots: any[] = []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let geoLines: any[] = []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let geoPreviewLine: any = null
+
     const toSurface = (e: { clientX: number; clientY: number }) =>
         zui.clientToSurface(e.clientX, e.clientY)
     zui.addLimits(0.06, 8)
@@ -271,6 +289,157 @@ function addZUI(
         const root = document.getElementById('main-two-root')
         if (root) root.style.cursor = cursor
     }
+
+    // ── Geo multi-click draw helpers (area / route) ──────────────────────────
+    const addGeoVertex = (x: number, y: number) => {
+        geoVertices.push({ x, y })
+        // Read the live element defaults (kept in sync via useEffect) so a
+        // stroke/width change made in the geo panel mid-draw is reflected
+        // immediately — same contract as pencil. Falls back to the props
+        // stashed at tool-pick, then the global shape default.
+        const stroke =
+            defaultStrokeColorValue ||
+            geoDrawProps?.stroke ||
+            SHAPE_DEFAULT_STROKE
+        const lw = defaultLinewidthValue || geoDrawProps?.linewidth || 2
+        const dot = two.makeCircle(x, y, 4)
+        dot.fill = stroke
+        dot.noStroke()
+        geoDots.push(dot)
+        if (geoVertices.length >= 2) {
+            const prev = geoVertices[geoVertices.length - 2]!
+            const line = two.makeLine(prev.x, prev.y, x, y)
+            line.stroke = stroke
+            line.linewidth = lw
+            line.opacity = 0.6
+            geoLines.push(line)
+        }
+        two.update()
+    }
+
+    const updateGeoPreview = (sx: number, sy: number) => {
+        if (!geoDrawType || geoVertices.length === 0) return
+        const last = geoVertices[geoVertices.length - 1]!
+        const stroke =
+            defaultStrokeColorValue ||
+            geoDrawProps?.stroke ||
+            SHAPE_DEFAULT_STROKE
+        const lw = defaultLinewidthValue || geoDrawProps?.linewidth || 2
+        if (geoPreviewLine) {
+            geoPreviewLine.vertices[0].set(last.x, last.y)
+            geoPreviewLine.vertices[1].set(sx, sy)
+        } else {
+            geoPreviewLine = two.makeLine(last.x, last.y, sx, sy)
+            geoPreviewLine.stroke = stroke
+            geoPreviewLine.linewidth = lw
+            geoPreviewLine.opacity = 0.35
+        }
+        two.update()
+    }
+
+    const clearGeoPreviewArtifacts = () => {
+        geoDots.forEach((d) => two.remove(d))
+        geoLines.forEach((l) => two.remove(l))
+        if (geoPreviewLine) two.remove(geoPreviewLine)
+        geoDots = []
+        geoLines = []
+        geoPreviewLine = null
+        two.update()
+    }
+
+    const resetGeoDrawState = () => {
+        geoDrawType = null
+        geoDrawProps = null
+        geoVertices = []
+        localStorage.removeItem(GEO_DRAW_MODE_KEY)
+        localStorage.removeItem(GEO_DRAW_TYPE_KEY)
+        localStorage.removeItem(GEO_DRAW_PROPS_KEY)
+        domElement.removeEventListener('mousemove', mousemove, false)
+    }
+
+    const cancelGeoDraw = () => {
+        clearGeoPreviewArtifacts()
+        resetGeoDrawState()
+        setRootCursor('auto')
+    }
+
+    // Finish a multi-click area/route. `dropLast` strips the duplicate vertex
+    // that the second mousedown of a double-click adds. Below the minimum vertex
+    // count, the draw is discarded.
+    const finishGeoDraw = ({
+        dropLast = false,
+    }: { dropLast?: boolean } = {}) => {
+        if (!geoDrawType) return
+        let verts = geoVertices.slice()
+        if (dropLast && verts.length > 0) verts = verts.slice(0, -1)
+
+        if (verts.length < GEO_MIN_VERTICES[geoDrawType]) {
+            cancelGeoDraw()
+            setPointerElement('pointer')
+            return
+        }
+
+        const type = geoDrawType
+        const originX = Math.floor(verts[0]!.x)
+        const originY = Math.floor(verts[0]!.y)
+        const finalId = generateUUID()
+        const finalShapeData = {
+            ...(geoDrawProps || {}),
+            id: finalId,
+            componentType: type,
+            objectClass: 'geo',
+            // Stroke/width/type come from the live element defaults so geo
+            // draws honor edits made in the panel (just like pencil/shapes),
+            // sharing the one default set across shapes/pencil/geo.
+            stroke:
+                defaultStrokeColorValue ||
+                geoDrawProps?.stroke ||
+                SHAPE_DEFAULT_STROKE,
+            linewidth: defaultLinewidthValue || geoDrawProps?.linewidth || 2,
+            strokeType: defaultStrokeTypeValue,
+            x: originX,
+            y: originY,
+            x1: 0,
+            x2: 0,
+            y1: 0,
+            y2: 0,
+            width: 0,
+            height: 0,
+            radius: null,
+            iconStroke: null,
+            isDummy: null,
+            createdAt: null,
+            children: {},
+            // Absolute vertex coords (same convention as pencil).
+            metadata: verts.map((v) => ({
+                x: Math.round(v.x),
+                y: Math.round(v.y),
+            })),
+        }
+
+        clearGeoPreviewArtifacts()
+        resetGeoDrawState()
+        addToLocalComponentStore(
+            finalId,
+            type,
+            finalShapeData as unknown as ComponentRecord
+        )
+        setSelectedComponentInBoard(null)
+        setPointerElement('pointer')
+        setRootCursor('auto')
+    }
+
+    window.addEventListener('cancelGeoDraw', () => {
+        if (geoDrawType) cancelGeoDraw()
+    })
+
+    window.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (!geoDrawType) return
+        if (e.key === 'Enter' || e.key === 'Escape') {
+            e.preventDefault()
+            finishGeoDraw({})
+        }
+    })
 
     const selectionController = new SelectionController({
         two,
@@ -316,6 +485,12 @@ function addZUI(
     })
 
     function dblclick(e: MouseEvent) {
+        // In a multi-click geo draw, a double-click finishes it. Drop the
+        // duplicate vertex the second mousedown added.
+        if (geoDrawType) {
+            finishGeoDraw({ dropLast: true })
+            return
+        }
         shape = null
         mouse.x = e.clientX
         mouse.y = e.clientY
@@ -346,13 +521,12 @@ function addZUI(
                 localStorage.getItem(RUBBER_MODE_KEY) === 'true' ||
                 localStorage.getItem(TEXT_DRAW_MODE_KEY) === 'true' ||
                 localStorage.getItem(ARROW_DRAW_MODE_KEY) === 'true' ||
+                localStorage.getItem(GEO_DRAW_MODE_KEY) === 'true' ||
+                localStorage.getItem(GEO_POINT_PLACE_MODE_KEY) === 'true' ||
                 localStorage.getItem(PENDING_SHAPE_TYPE_KEY) !== null
             if (!inDrawMode && createTextAtSurfaceRef?.current) {
                 const surfaceCoords = toSurface(e)
-                createTextAtSurfaceRef.current(
-                    surfaceCoords.x,
-                    surfaceCoords.y
-                )
+                createTextAtSurfaceRef.current(surfaceCoords.x, surfaceCoords.y)
                 return
             }
         }
@@ -459,7 +633,8 @@ function addZUI(
             // px-per-surface-unit derived from the shape's current screen
             // size; converts the textarea's pixel measurement back into
             // Two.js surface units before growing the shape.
-            const rectScreen = rectChild?._renderer?.elem?.getBoundingClientRect()
+            const rectScreen =
+                rectChild?._renderer?.elem?.getBoundingClientRect()
             const zoom =
                 rectChild && rectScreen && rectChild.width
                     ? rectScreen.width / rectChild.width
@@ -593,10 +768,8 @@ function addZUI(
                         hasText: true,
                         textContent: newContent,
                         textFill: latestMeta.textFill || textStyle.fill,
-                        textFontSize:
-                            latestMeta.textFontSize || textStyle.size,
-                        textFamily:
-                            latestMeta.textFamily || textStyle.family,
+                        textFontSize: latestMeta.textFontSize || textStyle.size,
+                        textFamily: latestMeta.textFamily || textStyle.family,
                         textFontFamily:
                             latestMeta.textFontFamily || textStyle.family,
                         textBaseLine:
@@ -695,6 +868,13 @@ function addZUI(
     hoverCircle.opacity = 0
 
     function hoverDetectMove(e: MouseEvent) {
+        // No arrow-endpoint hover while drawing/placing a geo object.
+        if (
+            geoDrawType ||
+            localStorage.getItem(GEO_POINT_PLACE_MODE_KEY) === 'true'
+        ) {
+            return
+        }
         if (!isSelectPanMode(isPencilModeRef.current)) {
             if (lastHoveredCircleGroup) {
                 hoverCircle.opacity = 0
@@ -797,12 +977,20 @@ function addZUI(
         const textDrawMode = localStorage.getItem(TEXT_DRAW_MODE_KEY)
         const pendingShapeType = localStorage.getItem(PENDING_SHAPE_TYPE_KEY)
         const rubberMode = localStorage.getItem(RUBBER_MODE_KEY)
+        const geoPointPlaceMode = localStorage.getItem(GEO_POINT_PLACE_MODE_KEY)
+        const geoDrawMode = localStorage.getItem(GEO_DRAW_MODE_KEY)
         if (rubberMode === 'true') {
             scenario = SCENARIO_RUBBER_MODE
         } else if (arrowDrawMode === 'true') {
             scenario = SCENARIO_ARROW_DRAW
         } else if (textDrawMode === 'true') {
             scenario = SCENARIO_TEXT_DRAW
+        } else if (geoPointPlaceMode === 'true') {
+            // checked before JUST_ADDED_ELEMENT: point place also sets
+            // LAST_ADDED_ELEMENT_ID_KEY (the pre-created point).
+            scenario = SCENARIO_GEO_POINT
+        } else if (geoDrawMode === 'true') {
+            scenario = SCENARIO_GEO_DRAW
         } else if (pendingShapeType !== null) {
             scenario = SCENARIO_DRAW_SHAPE
         } else if (lastAddedElementId !== null) {
@@ -892,6 +1080,59 @@ function addZUI(
                 setRootCursor('auto')
                 break
             }
+            case SCENARIO_GEO_POINT: {
+                const surfaceCoords = toSurface(e)
+                const pointId = localStorage.getItem(LAST_ADDED_ELEMENT_ID_KEY)
+
+                localStorage.removeItem(LAST_ADDED_ELEMENT_ID_KEY)
+                localStorage.removeItem(GEO_POINT_PLACE_MODE_KEY)
+
+                // The point module loads lazily on first use — poll until the
+                // pre-created element appears, then drop it at the click point.
+                if (pointId) {
+                    pollUntilElement(
+                        two,
+                        pointId,
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        (el: any) => {
+                            el.position.x = surfaceCoords.x
+                            el.position.y = surfaceCoords.y
+                            two.update()
+                            updateComponentVertices(
+                                pointId,
+                                surfaceCoords.x,
+                                surfaceCoords.y
+                            )
+                        },
+                        { maxRetries: 30 }
+                    )
+                }
+
+                setSelectedComponentInBoard(null)
+                setPointerElement('pointer')
+                setRootCursor('auto')
+                break
+            }
+            case SCENARIO_GEO_DRAW: {
+                const surfaceCoords = toSurface(e)
+                // First click of this draw — capture type/props from storage.
+                if (!geoDrawType) {
+                    geoDrawType = localStorage.getItem(GEO_DRAW_TYPE_KEY) as
+                        | 'area'
+                        | 'route'
+                        | null
+                    geoDrawProps = JSON.parse(
+                        localStorage.getItem(GEO_DRAW_PROPS_KEY) ?? 'null'
+                    )
+                    geoVertices = []
+                    domElement.addEventListener('mousemove', mousemove, false)
+                }
+                if (geoDrawType) {
+                    addGeoVertex(surfaceCoords.x, surfaceCoords.y)
+                    setRootCursor('crosshair')
+                }
+                break
+            }
             case SCENARIO_DRAW_SHAPE: {
                 const surfaceCoords = toSurface(e)
                 drawOrigin = { x: surfaceCoords.x, y: surfaceCoords.y }
@@ -950,7 +1191,8 @@ function addZUI(
 
                 let twoJSElement = two.scene.children.find(
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    (child: any) => child?.elementData?.id === lastAddedElementId
+                    (child: any) =>
+                        child?.elementData?.id === lastAddedElementId
                 )
 
                 if (twoJSElement?.position && lastAddedElementId) {
@@ -1039,8 +1281,8 @@ function addZUI(
                 })
 
                 const path =
-            (e as MouseEvent & { path?: EventTarget[] }).path ||
-            (e.composedPath && e.composedPath())
+                    (e as MouseEvent & { path?: EventTarget[] }).path ||
+                    (e.composedPath && e.composedPath())
                 ;({ shape, avoidDragging } = resolveShapeFromPath(path, two))
 
                 // Endpoint circles are opacity:0 so pointer-events don't fire on them.
@@ -1230,6 +1472,13 @@ function addZUI(
     }
 
     function mousemove(e: MouseEvent) {
+        // Multi-click geo draw: rubber-band the preview line to the cursor.
+        if (geoDrawType) {
+            const s = toSurface(e)
+            updateGeoPreview(s.x, s.y)
+            return
+        }
+
         const lastAddedElementId = localStorage.getItem(
             LAST_ADDED_ELEMENT_ID_KEY
         )
@@ -1298,7 +1547,8 @@ function addZUI(
 
                 let twoJSElement = two.scene.children.find(
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    (child: any) => child?.elementData?.id === lastAddedElementId
+                    (child: any) =>
+                        child?.elementData?.id === lastAddedElementId
                 )
 
                 if (twoJSElement?.position) {
@@ -1776,10 +2026,8 @@ function addZUI(
                     // check on mouse up if shape's a group selector or not
                     // if yes, then call setOnGroup for adding a group in two.js space
                     let area = shape.children[0]
-                    const groupWidth =
-                        area.vertices[2].x - area.vertices[0].x
-                    const groupHeight =
-                        area.vertices[3].y - area.vertices[0].y
+                    const groupWidth = area.vertices[2].x - area.vertices[0].x
+                    const groupHeight = area.vertices[3].y - area.vertices[0].y
                     two.remove(shape)
                     // The selector starts as a 10x10 rect (see mousedown). If
                     // it never grew, the user just clicked without dragging —
@@ -2519,8 +2767,12 @@ const Canvas: React.FC<CanvasProps> = (props) => {
                     let relativeY = item.y - yMid
 
                     let newMetadata = item.metadata
+                    // pencil + geo area/route all store an absolute {x,y} vertex
+                    // array; remap it into the group's child coordinate space.
                     if (
-                        item.componentType === 'pencil' &&
+                        (item.componentType === 'pencil' ||
+                            item.componentType === 'area' ||
+                            item.componentType === 'route') &&
                         Array.isArray(item.metadata)
                     ) {
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2605,10 +2857,7 @@ const Canvas: React.FC<CanvasProps> = (props) => {
 
     useEffect(() => {
         const onUndoRedoKeyDown = (evt: KeyboardEvent) => {
-            if (
-                evt.key.toLowerCase() === 'z' &&
-                (evt.ctrlKey || evt.metaKey)
-            ) {
+            if (evt.key.toLowerCase() === 'z' && (evt.ctrlKey || evt.metaKey)) {
                 evt.preventDefault()
                 if (evt.shiftKey) {
                     redoLastAction()
@@ -2628,6 +2877,8 @@ const Canvas: React.FC<CanvasProps> = (props) => {
                 localStorage.getItem(ARROW_DRAW_MODE_KEY) === 'true' ||
                 localStorage.getItem(RUBBER_MODE_KEY) === 'true' ||
                 localStorage.getItem(PENCIL_MODE_KEY) === 'TRUE' ||
+                localStorage.getItem(GEO_DRAW_MODE_KEY) === 'true' ||
+                localStorage.getItem(GEO_POINT_PLACE_MODE_KEY) === 'true' ||
                 localStorage.getItem(PENDING_SHAPE_TYPE_KEY) !== null
             )
                 return

--- a/src/newCanvas.tsx
+++ b/src/newCanvas.tsx
@@ -165,7 +165,10 @@ function addZUI(
     setSelectedComponentInBoard: (component: SelectedComponent | null) => void,
     setArrowDrawModeOff: () => void,
     setTextDrawModeOff: () => void,
-    setPointerElement: (element: CurrentElement | null) => void,
+    setPointerElement: (
+        element: CurrentElement | null,
+        options?: { select?: boolean }
+    ) => void,
     updateComponentBulkPropertiesInLocalStore: (
         id: string,
         update: Partial<ComponentRecord>,
@@ -381,7 +384,7 @@ function addZUI(
 
         if (verts.length < GEO_MIN_VERTICES[geoDrawType]) {
             cancelGeoDraw()
-            setPointerElement('pointer')
+            setPointerElement('pointer', { select: true })
             return
         }
 
@@ -431,10 +434,10 @@ function addZUI(
             finalShapeData as unknown as ComponentRecord
         )
         setSelectedComponentInBoard(null)
-        // Reset cursor first: when geo is enabled setPointerElement re-activates
-        // pan, which sets its own 'grab' cursor that should win.
+        // After finishing an area/route draw, land in pointer/select mode so the
+        // shape can be tweaked immediately (instead of pan, the geo home tool).
         setRootCursor('auto')
-        setPointerElement('pointer')
+        setPointerElement('pointer', { select: true })
     }
 
     window.addEventListener('cancelGeoDraw', () => {
@@ -972,6 +975,11 @@ function addZUI(
         ) {
             let evt = new CustomEvent('clearSelector', {})
             window.dispatchEvent(evt)
+            // clearSelector only detaches the visual selector; the React
+            // selectedComponent stays set, which keeps the point tooltip
+            // pinned. Clear it too so the tooltip dismisses immediately when
+            // the user clicks bare canvas.
+            setSelectedComponentInBoard(null)
         }
 
         // Reset scenario to prevent stale state from a previous interaction
@@ -1134,7 +1142,7 @@ function addZUI(
                 }
 
                 setSelectedComponentInBoard(null)
-                setPointerElement('pointer')
+                setPointerElement('pointer', { select: true })
                 setRootCursor('auto')
                 break
             }
@@ -1923,7 +1931,9 @@ function addZUI(
 
                 textDrawElement = null
                 setTextDrawModeOff()
-                setPointerElement('pointer')
+                // In geo mode the only text tool is geoText; land in pointer so
+                // the placed text can be selected (no effect when geo is off).
+                setPointerElement('pointer', { select: true })
                 setRootCursor('auto')
                 domElement.removeEventListener('mouseup', mouseup, false)
                 break
@@ -2580,10 +2590,21 @@ const Canvas: React.FC<CanvasProps> = (props) => {
     } = useBoardContext()
 
     // addZUI's post-draw resets funnel a 'pointer' through setPointerElement.
-    // With geo objects enabled the home tool is pan (pointer is hidden), so
-    // re-activate pan instead of stranding the user in hidden select mode.
-    const resetToHomeTool = (element: CurrentElement | null): void => {
+    // With geo objects enabled the home tool is pan, so a generic reset
+    // re-activates pan instead of stranding the user in select mode. The
+    // exception is finishing a geo draw (point/area/route): we want the user
+    // dropped straight into pointer/select so the just-placed object can be
+    // tweaked — callers signal that with { select: true }.
+    const resetToHomeTool = (
+        element: CurrentElement | null,
+        options?: { select?: boolean }
+    ): void => {
         if (element === 'pointer' && geoObjectsEnabled) {
+            if (options?.select) {
+                togglePanMode(false)
+                setCurrentElementInBoard('pointer')
+                return
+            }
             togglePanMode(true)
             setCurrentElementInBoard('pan')
             return

--- a/src/schema/generated.ts
+++ b/src/schema/generated.ts
@@ -546,6 +546,7 @@ export type Components_Component = {
   isDummy?: Maybe<Scalars['Boolean']['output']>;
   linewidth?: Maybe<Scalars['float8']['output']>;
   metadata?: Maybe<Scalars['jsonb']['output']>;
+  objectClass: Scalars['String']['output'];
   position: Scalars['Int']['output'];
   radius?: Maybe<Scalars['float8']['output']>;
   stroke?: Maybe<Scalars['String']['output']>;
@@ -971,6 +972,7 @@ export type Components_Component_Bool_Exp = {
   isDummy?: InputMaybe<Boolean_Comparison_Exp>;
   linewidth?: InputMaybe<Float8_Comparison_Exp>;
   metadata?: InputMaybe<Jsonb_Comparison_Exp>;
+  objectClass?: InputMaybe<String_Comparison_Exp>;
   position?: InputMaybe<Int_Comparison_Exp>;
   radius?: InputMaybe<Float8_Comparison_Exp>;
   stroke?: InputMaybe<String_Comparison_Exp>;
@@ -1043,6 +1045,7 @@ export type Components_Component_Insert_Input = {
   isDummy?: InputMaybe<Scalars['Boolean']['input']>;
   linewidth?: InputMaybe<Scalars['float8']['input']>;
   metadata?: InputMaybe<Scalars['jsonb']['input']>;
+  objectClass?: InputMaybe<Scalars['String']['input']>;
   position?: InputMaybe<Scalars['Int']['input']>;
   radius?: InputMaybe<Scalars['float8']['input']>;
   stroke?: InputMaybe<Scalars['String']['input']>;
@@ -1071,6 +1074,7 @@ export type Components_Component_Max_Fields = {
   iconStroke?: Maybe<Scalars['String']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
   linewidth?: Maybe<Scalars['float8']['output']>;
+  objectClass?: Maybe<Scalars['String']['output']>;
   position?: Maybe<Scalars['Int']['output']>;
   radius?: Maybe<Scalars['float8']['output']>;
   stroke?: Maybe<Scalars['String']['output']>;
@@ -1099,6 +1103,7 @@ export type Components_Component_Min_Fields = {
   iconStroke?: Maybe<Scalars['String']['output']>;
   id?: Maybe<Scalars['uuid']['output']>;
   linewidth?: Maybe<Scalars['float8']['output']>;
+  objectClass?: Maybe<Scalars['String']['output']>;
   position?: Maybe<Scalars['Int']['output']>;
   radius?: Maybe<Scalars['float8']['output']>;
   stroke?: Maybe<Scalars['String']['output']>;
@@ -1146,6 +1151,7 @@ export type Components_Component_Order_By = {
   isDummy?: InputMaybe<Order_By>;
   linewidth?: InputMaybe<Order_By>;
   metadata?: InputMaybe<Order_By>;
+  objectClass?: InputMaybe<Order_By>;
   position?: InputMaybe<Order_By>;
   radius?: InputMaybe<Order_By>;
   stroke?: InputMaybe<Order_By>;
@@ -1201,6 +1207,8 @@ export type Components_Component_Select_Column =
   /** column name */
   | 'metadata'
   /** column name */
+  | 'objectClass'
+  /** column name */
   | 'position'
   /** column name */
   | 'radius'
@@ -1242,6 +1250,7 @@ export type Components_Component_Set_Input = {
   isDummy?: InputMaybe<Scalars['Boolean']['input']>;
   linewidth?: InputMaybe<Scalars['float8']['input']>;
   metadata?: InputMaybe<Scalars['jsonb']['input']>;
+  objectClass?: InputMaybe<Scalars['String']['input']>;
   position?: InputMaybe<Scalars['Int']['input']>;
   radius?: InputMaybe<Scalars['float8']['input']>;
   stroke?: InputMaybe<Scalars['String']['input']>;
@@ -1331,6 +1340,7 @@ export type Components_Component_Stream_Cursor_Value_Input = {
   isDummy?: InputMaybe<Scalars['Boolean']['input']>;
   linewidth?: InputMaybe<Scalars['float8']['input']>;
   metadata?: InputMaybe<Scalars['jsonb']['input']>;
+  objectClass?: InputMaybe<Scalars['String']['input']>;
   position?: InputMaybe<Scalars['Int']['input']>;
   radius?: InputMaybe<Scalars['float8']['input']>;
   stroke?: InputMaybe<Scalars['String']['input']>;
@@ -1391,6 +1401,8 @@ export type Components_Component_Update_Column =
   | 'linewidth'
   /** column name */
   | 'metadata'
+  /** column name */
+  | 'objectClass'
   /** column name */
   | 'position'
   /** column name */
@@ -1488,6 +1500,275 @@ export type Components_Component_Variance_Fields = {
   y2?: Maybe<Scalars['Float']['output']>;
 };
 
+/** columns and relationships of "components.geoObjectType" */
+export type Components_GeoObjectType = {
+  __typename?: 'components_geoObjectType';
+  defaultStroke?: Maybe<Scalars['String']['output']>;
+  label: Scalars['String']['output'];
+  linewidth?: Maybe<Scalars['Int']['output']>;
+  logo?: Maybe<Scalars['String']['output']>;
+  metadata?: Maybe<Scalars['jsonb']['output']>;
+};
+
+
+/** columns and relationships of "components.geoObjectType" */
+export type Components_GeoObjectTypeMetadataArgs = {
+  path?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** aggregated selection of "components.geoObjectType" */
+export type Components_GeoObjectType_Aggregate = {
+  __typename?: 'components_geoObjectType_aggregate';
+  aggregate?: Maybe<Components_GeoObjectType_Aggregate_Fields>;
+  nodes: Array<Components_GeoObjectType>;
+};
+
+/** aggregate fields of "components.geoObjectType" */
+export type Components_GeoObjectType_Aggregate_Fields = {
+  __typename?: 'components_geoObjectType_aggregate_fields';
+  avg?: Maybe<Components_GeoObjectType_Avg_Fields>;
+  count: Scalars['Int']['output'];
+  max?: Maybe<Components_GeoObjectType_Max_Fields>;
+  min?: Maybe<Components_GeoObjectType_Min_Fields>;
+  stddev?: Maybe<Components_GeoObjectType_Stddev_Fields>;
+  stddev_pop?: Maybe<Components_GeoObjectType_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Components_GeoObjectType_Stddev_Samp_Fields>;
+  sum?: Maybe<Components_GeoObjectType_Sum_Fields>;
+  var_pop?: Maybe<Components_GeoObjectType_Var_Pop_Fields>;
+  var_samp?: Maybe<Components_GeoObjectType_Var_Samp_Fields>;
+  variance?: Maybe<Components_GeoObjectType_Variance_Fields>;
+};
+
+
+/** aggregate fields of "components.geoObjectType" */
+export type Components_GeoObjectType_Aggregate_FieldsCountArgs = {
+  columns?: InputMaybe<Array<Components_GeoObjectType_Select_Column>>;
+  distinct?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** append existing jsonb value of filtered columns with new jsonb value */
+export type Components_GeoObjectType_Append_Input = {
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate avg on columns */
+export type Components_GeoObjectType_Avg_Fields = {
+  __typename?: 'components_geoObjectType_avg_fields';
+  linewidth?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Boolean expression to filter rows from the table "components.geoObjectType". All fields are combined with a logical 'AND'. */
+export type Components_GeoObjectType_Bool_Exp = {
+  _and?: InputMaybe<Array<Components_GeoObjectType_Bool_Exp>>;
+  _not?: InputMaybe<Components_GeoObjectType_Bool_Exp>;
+  _or?: InputMaybe<Array<Components_GeoObjectType_Bool_Exp>>;
+  defaultStroke?: InputMaybe<String_Comparison_Exp>;
+  label?: InputMaybe<String_Comparison_Exp>;
+  linewidth?: InputMaybe<Int_Comparison_Exp>;
+  logo?: InputMaybe<String_Comparison_Exp>;
+  metadata?: InputMaybe<Jsonb_Comparison_Exp>;
+};
+
+/** unique or primary key constraints on table "components.geoObjectType" */
+export type Components_GeoObjectType_Constraint =
+  /** unique or primary key constraint on columns "label" */
+  | 'geoObjectType_pkey';
+
+/** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+export type Components_GeoObjectType_Delete_At_Path_Input = {
+  metadata?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+export type Components_GeoObjectType_Delete_Elem_Input = {
+  metadata?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** delete key/value pair or string element. key/value pairs are matched based on their key value */
+export type Components_GeoObjectType_Delete_Key_Input = {
+  metadata?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** input type for incrementing numeric columns in table "components.geoObjectType" */
+export type Components_GeoObjectType_Inc_Input = {
+  linewidth?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/** input type for inserting data into table "components.geoObjectType" */
+export type Components_GeoObjectType_Insert_Input = {
+  defaultStroke?: InputMaybe<Scalars['String']['input']>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  linewidth?: InputMaybe<Scalars['Int']['input']>;
+  logo?: InputMaybe<Scalars['String']['input']>;
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate max on columns */
+export type Components_GeoObjectType_Max_Fields = {
+  __typename?: 'components_geoObjectType_max_fields';
+  defaultStroke?: Maybe<Scalars['String']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  linewidth?: Maybe<Scalars['Int']['output']>;
+  logo?: Maybe<Scalars['String']['output']>;
+};
+
+/** aggregate min on columns */
+export type Components_GeoObjectType_Min_Fields = {
+  __typename?: 'components_geoObjectType_min_fields';
+  defaultStroke?: Maybe<Scalars['String']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  linewidth?: Maybe<Scalars['Int']['output']>;
+  logo?: Maybe<Scalars['String']['output']>;
+};
+
+/** response of any mutation on the table "components.geoObjectType" */
+export type Components_GeoObjectType_Mutation_Response = {
+  __typename?: 'components_geoObjectType_mutation_response';
+  /** number of rows affected by the mutation */
+  affected_rows: Scalars['Int']['output'];
+  /** data from the rows affected by the mutation */
+  returning: Array<Components_GeoObjectType>;
+};
+
+/** on_conflict condition type for table "components.geoObjectType" */
+export type Components_GeoObjectType_On_Conflict = {
+  constraint: Components_GeoObjectType_Constraint;
+  update_columns?: Array<Components_GeoObjectType_Update_Column>;
+  where?: InputMaybe<Components_GeoObjectType_Bool_Exp>;
+};
+
+/** Ordering options when selecting data from "components.geoObjectType". */
+export type Components_GeoObjectType_Order_By = {
+  defaultStroke?: InputMaybe<Order_By>;
+  label?: InputMaybe<Order_By>;
+  linewidth?: InputMaybe<Order_By>;
+  logo?: InputMaybe<Order_By>;
+  metadata?: InputMaybe<Order_By>;
+};
+
+/** primary key columns input for table: components.geoObjectType */
+export type Components_GeoObjectType_Pk_Columns_Input = {
+  label: Scalars['String']['input'];
+};
+
+/** prepend existing jsonb value of filtered columns with new jsonb value */
+export type Components_GeoObjectType_Prepend_Input = {
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** select columns of table "components.geoObjectType" */
+export type Components_GeoObjectType_Select_Column =
+  /** column name */
+  | 'defaultStroke'
+  /** column name */
+  | 'label'
+  /** column name */
+  | 'linewidth'
+  /** column name */
+  | 'logo'
+  /** column name */
+  | 'metadata';
+
+/** input type for updating data in table "components.geoObjectType" */
+export type Components_GeoObjectType_Set_Input = {
+  defaultStroke?: InputMaybe<Scalars['String']['input']>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  linewidth?: InputMaybe<Scalars['Int']['input']>;
+  logo?: InputMaybe<Scalars['String']['input']>;
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate stddev on columns */
+export type Components_GeoObjectType_Stddev_Fields = {
+  __typename?: 'components_geoObjectType_stddev_fields';
+  linewidth?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Components_GeoObjectType_Stddev_Pop_Fields = {
+  __typename?: 'components_geoObjectType_stddev_pop_fields';
+  linewidth?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Components_GeoObjectType_Stddev_Samp_Fields = {
+  __typename?: 'components_geoObjectType_stddev_samp_fields';
+  linewidth?: Maybe<Scalars['Float']['output']>;
+};
+
+/** Streaming cursor of the table "components_geoObjectType" */
+export type Components_GeoObjectType_Stream_Cursor_Input = {
+  /** Stream column input with initial value */
+  initial_value: Components_GeoObjectType_Stream_Cursor_Value_Input;
+  /** cursor ordering */
+  ordering?: InputMaybe<Cursor_Ordering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type Components_GeoObjectType_Stream_Cursor_Value_Input = {
+  defaultStroke?: InputMaybe<Scalars['String']['input']>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  linewidth?: InputMaybe<Scalars['Int']['input']>;
+  logo?: InputMaybe<Scalars['String']['input']>;
+  metadata?: InputMaybe<Scalars['jsonb']['input']>;
+};
+
+/** aggregate sum on columns */
+export type Components_GeoObjectType_Sum_Fields = {
+  __typename?: 'components_geoObjectType_sum_fields';
+  linewidth?: Maybe<Scalars['Int']['output']>;
+};
+
+/** update columns of table "components.geoObjectType" */
+export type Components_GeoObjectType_Update_Column =
+  /** column name */
+  | 'defaultStroke'
+  /** column name */
+  | 'label'
+  /** column name */
+  | 'linewidth'
+  /** column name */
+  | 'logo'
+  /** column name */
+  | 'metadata';
+
+export type Components_GeoObjectType_Updates = {
+  /** append existing jsonb value of filtered columns with new jsonb value */
+  _append?: InputMaybe<Components_GeoObjectType_Append_Input>;
+  /** delete the field or element with specified path (for JSON arrays, negative integers count from the end) */
+  _delete_at_path?: InputMaybe<Components_GeoObjectType_Delete_At_Path_Input>;
+  /** delete the array element with specified index (negative integers count from the end). throws an error if top level container is not an array */
+  _delete_elem?: InputMaybe<Components_GeoObjectType_Delete_Elem_Input>;
+  /** delete key/value pair or string element. key/value pairs are matched based on their key value */
+  _delete_key?: InputMaybe<Components_GeoObjectType_Delete_Key_Input>;
+  /** increments the numeric columns with given value of the filtered values */
+  _inc?: InputMaybe<Components_GeoObjectType_Inc_Input>;
+  /** prepend existing jsonb value of filtered columns with new jsonb value */
+  _prepend?: InputMaybe<Components_GeoObjectType_Prepend_Input>;
+  /** sets the columns of the filtered rows to the given values */
+  _set?: InputMaybe<Components_GeoObjectType_Set_Input>;
+  /** filter the rows which have to be updated */
+  where: Components_GeoObjectType_Bool_Exp;
+};
+
+/** aggregate var_pop on columns */
+export type Components_GeoObjectType_Var_Pop_Fields = {
+  __typename?: 'components_geoObjectType_var_pop_fields';
+  linewidth?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate var_samp on columns */
+export type Components_GeoObjectType_Var_Samp_Fields = {
+  __typename?: 'components_geoObjectType_var_samp_fields';
+  linewidth?: Maybe<Scalars['Float']['output']>;
+};
+
+/** aggregate variance on columns */
+export type Components_GeoObjectType_Variance_Fields = {
+  __typename?: 'components_geoObjectType_variance_fields';
+  linewidth?: Maybe<Scalars['Float']['output']>;
+};
+
 /** ordering argument of a cursor */
 export type Cursor_Ordering =
   /** ascending ordering of the cursor */
@@ -1551,6 +1832,10 @@ export type Mutation_Root = {
   delete_components_componentType_by_pk?: Maybe<Components_ComponentType>;
   /** delete single row from the table: "components.component" */
   delete_components_component_by_pk?: Maybe<Components_Component>;
+  /** delete data from the table: "components.geoObjectType" */
+  delete_components_geoObjectType?: Maybe<Components_GeoObjectType_Mutation_Response>;
+  /** delete single row from the table: "components.geoObjectType" */
+  delete_components_geoObjectType_by_pk?: Maybe<Components_GeoObjectType>;
   /** delete data from the table: "test" */
   delete_test?: Maybe<Test_Mutation_Response>;
   /** delete single row from the table: "test" */
@@ -1575,6 +1860,10 @@ export type Mutation_Root = {
   insert_components_componentType_one?: Maybe<Components_ComponentType>;
   /** insert a single row into the table: "components.component" */
   insert_components_component_one?: Maybe<Components_Component>;
+  /** insert data into the table: "components.geoObjectType" */
+  insert_components_geoObjectType?: Maybe<Components_GeoObjectType_Mutation_Response>;
+  /** insert a single row into the table: "components.geoObjectType" */
+  insert_components_geoObjectType_one?: Maybe<Components_GeoObjectType>;
   /** insert data into the table: "test" */
   insert_test?: Maybe<Test_Mutation_Response>;
   /** insert a single row into the table: "test" */
@@ -1605,6 +1894,12 @@ export type Mutation_Root = {
   update_components_component_by_pk?: Maybe<Components_Component>;
   /** update multiples rows of table: "components.component" */
   update_components_component_many?: Maybe<Array<Maybe<Components_Component_Mutation_Response>>>;
+  /** update data of the table: "components.geoObjectType" */
+  update_components_geoObjectType?: Maybe<Components_GeoObjectType_Mutation_Response>;
+  /** update single row of the table: "components.geoObjectType" */
+  update_components_geoObjectType_by_pk?: Maybe<Components_GeoObjectType>;
+  /** update multiples rows of table: "components.geoObjectType" */
+  update_components_geoObjectType_many?: Maybe<Array<Maybe<Components_GeoObjectType_Mutation_Response>>>;
   /** update data of the table: "test" */
   update_test?: Maybe<Test_Mutation_Response>;
   /** update single row of the table: "test" */
@@ -1659,6 +1954,18 @@ export type Mutation_RootDelete_Components_ComponentType_By_PkArgs = {
 /** mutation root */
 export type Mutation_RootDelete_Components_Component_By_PkArgs = {
   id: Scalars['uuid']['input'];
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Components_GeoObjectTypeArgs = {
+  where: Components_GeoObjectType_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootDelete_Components_GeoObjectType_By_PkArgs = {
+  label: Scalars['String']['input'];
 };
 
 
@@ -1737,6 +2044,20 @@ export type Mutation_RootInsert_Components_ComponentType_OneArgs = {
 export type Mutation_RootInsert_Components_Component_OneArgs = {
   object: Components_Component_Insert_Input;
   on_conflict?: InputMaybe<Components_Component_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Components_GeoObjectTypeArgs = {
+  objects: Array<Components_GeoObjectType_Insert_Input>;
+  on_conflict?: InputMaybe<Components_GeoObjectType_On_Conflict>;
+};
+
+
+/** mutation root */
+export type Mutation_RootInsert_Components_GeoObjectType_OneArgs = {
+  object: Components_GeoObjectType_Insert_Input;
+  on_conflict?: InputMaybe<Components_GeoObjectType_On_Conflict>;
 };
 
 
@@ -1879,6 +2200,38 @@ export type Mutation_RootUpdate_Components_Component_ManyArgs = {
 
 
 /** mutation root */
+export type Mutation_RootUpdate_Components_GeoObjectTypeArgs = {
+  _append?: InputMaybe<Components_GeoObjectType_Append_Input>;
+  _delete_at_path?: InputMaybe<Components_GeoObjectType_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Components_GeoObjectType_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Components_GeoObjectType_Delete_Key_Input>;
+  _inc?: InputMaybe<Components_GeoObjectType_Inc_Input>;
+  _prepend?: InputMaybe<Components_GeoObjectType_Prepend_Input>;
+  _set?: InputMaybe<Components_GeoObjectType_Set_Input>;
+  where: Components_GeoObjectType_Bool_Exp;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Components_GeoObjectType_By_PkArgs = {
+  _append?: InputMaybe<Components_GeoObjectType_Append_Input>;
+  _delete_at_path?: InputMaybe<Components_GeoObjectType_Delete_At_Path_Input>;
+  _delete_elem?: InputMaybe<Components_GeoObjectType_Delete_Elem_Input>;
+  _delete_key?: InputMaybe<Components_GeoObjectType_Delete_Key_Input>;
+  _inc?: InputMaybe<Components_GeoObjectType_Inc_Input>;
+  _prepend?: InputMaybe<Components_GeoObjectType_Prepend_Input>;
+  _set?: InputMaybe<Components_GeoObjectType_Set_Input>;
+  pk_columns: Components_GeoObjectType_Pk_Columns_Input;
+};
+
+
+/** mutation root */
+export type Mutation_RootUpdate_Components_GeoObjectType_ManyArgs = {
+  updates: Array<Components_GeoObjectType_Updates>;
+};
+
+
+/** mutation root */
 export type Mutation_RootUpdate_TestArgs = {
   _inc?: InputMaybe<Test_Inc_Input>;
   _set?: InputMaybe<Test_Set_Input>;
@@ -1976,6 +2329,12 @@ export type Query_Root = {
   components_component_aggregate: Components_Component_Aggregate;
   /** fetch data from the table: "components.component" using primary key columns */
   components_component_by_pk?: Maybe<Components_Component>;
+  /** fetch data from the table: "components.geoObjectType" */
+  components_geoObjectType: Array<Components_GeoObjectType>;
+  /** fetch aggregated fields from the table: "components.geoObjectType" */
+  components_geoObjectType_aggregate: Components_GeoObjectType_Aggregate;
+  /** fetch data from the table: "components.geoObjectType" using primary key columns */
+  components_geoObjectType_by_pk?: Maybe<Components_GeoObjectType>;
   /** fetch data from the table: "test" */
   test: Array<Test>;
   /** fetch aggregated fields from the table: "test" */
@@ -2063,6 +2422,29 @@ export type Query_RootComponents_Component_AggregateArgs = {
 
 export type Query_RootComponents_Component_By_PkArgs = {
   id: Scalars['uuid']['input'];
+};
+
+
+export type Query_RootComponents_GeoObjectTypeArgs = {
+  distinct_on?: InputMaybe<Array<Components_GeoObjectType_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Components_GeoObjectType_Order_By>>;
+  where?: InputMaybe<Components_GeoObjectType_Bool_Exp>;
+};
+
+
+export type Query_RootComponents_GeoObjectType_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Components_GeoObjectType_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Components_GeoObjectType_Order_By>>;
+  where?: InputMaybe<Components_GeoObjectType_Bool_Exp>;
+};
+
+
+export type Query_RootComponents_GeoObjectType_By_PkArgs = {
+  label: Scalars['String']['input'];
 };
 
 
@@ -2160,6 +2542,14 @@ export type Subscription_Root = {
   components_component_by_pk?: Maybe<Components_Component>;
   /** fetch data from the table in a streaming manner: "components.component" */
   components_component_stream: Array<Components_Component>;
+  /** fetch data from the table: "components.geoObjectType" */
+  components_geoObjectType: Array<Components_GeoObjectType>;
+  /** fetch aggregated fields from the table: "components.geoObjectType" */
+  components_geoObjectType_aggregate: Components_GeoObjectType_Aggregate;
+  /** fetch data from the table: "components.geoObjectType" using primary key columns */
+  components_geoObjectType_by_pk?: Maybe<Components_GeoObjectType>;
+  /** fetch data from the table in a streaming manner: "components.geoObjectType" */
+  components_geoObjectType_stream: Array<Components_GeoObjectType>;
   /** fetch data from the table: "test" */
   test: Array<Test>;
   /** fetch aggregated fields from the table: "test" */
@@ -2274,6 +2664,36 @@ export type Subscription_RootComponents_Component_StreamArgs = {
   batch_size: Scalars['Int']['input'];
   cursor: Array<InputMaybe<Components_Component_Stream_Cursor_Input>>;
   where?: InputMaybe<Components_Component_Bool_Exp>;
+};
+
+
+export type Subscription_RootComponents_GeoObjectTypeArgs = {
+  distinct_on?: InputMaybe<Array<Components_GeoObjectType_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Components_GeoObjectType_Order_By>>;
+  where?: InputMaybe<Components_GeoObjectType_Bool_Exp>;
+};
+
+
+export type Subscription_RootComponents_GeoObjectType_AggregateArgs = {
+  distinct_on?: InputMaybe<Array<Components_GeoObjectType_Select_Column>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<Components_GeoObjectType_Order_By>>;
+  where?: InputMaybe<Components_GeoObjectType_Bool_Exp>;
+};
+
+
+export type Subscription_RootComponents_GeoObjectType_By_PkArgs = {
+  label: Scalars['String']['input'];
+};
+
+
+export type Subscription_RootComponents_GeoObjectType_StreamArgs = {
+  batch_size: Scalars['Int']['input'];
+  cursor: Array<InputMaybe<Components_GeoObjectType_Stream_Cursor_Input>>;
+  where?: InputMaybe<Components_GeoObjectType_Bool_Exp>;
 };
 
 
@@ -3083,7 +3503,7 @@ export type GetComponentsForBoardQueryVariables = Exact<{
 }>;
 
 
-export type GetComponentsForBoardQuery = { __typename?: 'query_root', components: Array<{ __typename?: 'components_component', id: string, componentType: string, children?: unknown | null, metadata?: unknown | null, x: any, x1: any, x2: any, y: any, y1: any, y2: any, fill: string, width: any, height: any, iconStroke?: string | null, stroke?: string | null, linewidth?: any | null, strokeType?: string | null, textColor?: string | null }> };
+export type GetComponentsForBoardQuery = { __typename?: 'query_root', components: Array<{ __typename?: 'components_component', id: string, componentType: string, objectClass: string, children?: unknown | null, metadata?: unknown | null, x: any, x1: any, x2: any, y: any, y1: any, y2: any, fill: string, width: any, height: any, iconStroke?: string | null, stroke?: string | null, linewidth?: any | null, strokeType?: string | null, textColor?: string | null }> };
 
 export type GetComponentInfoQueryQueryVariables = Exact<{
   id?: InputMaybe<Scalars['uuid']['input']>;
@@ -3125,7 +3545,7 @@ export type GetComponentsForBoardSubscriptionSubscriptionVariables = Exact<{
 }>;
 
 
-export type GetComponentsForBoardSubscriptionSubscription = { __typename?: 'subscription_root', components: Array<{ __typename?: 'components_component', id: string, componentType: string, children?: unknown | null, metadata?: unknown | null, x: any, x1: any, x2: any, y: any, y1: any, y2: any, fill: string, width: any, height: any, iconStroke?: string | null, stroke?: string | null, linewidth?: any | null, strokeType?: string | null }> };
+export type GetComponentsForBoardSubscriptionSubscription = { __typename?: 'subscription_root', components: Array<{ __typename?: 'components_component', id: string, componentType: string, objectClass: string, children?: unknown | null, metadata?: unknown | null, x: any, x1: any, x2: any, y: any, y1: any, y2: any, fill: string, width: any, height: any, iconStroke?: string | null, stroke?: string | null, linewidth?: any | null, strokeType?: string | null }> };
 
 
 export const UpdateComponentInfoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"updateComponentInfo"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}},"defaultValue":{"kind":"StringValue","value":"","block":false}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"updateObj"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"components_component_set_input"}},"defaultValue":{"kind":"ObjectValue","fields":[]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"update_components_component_by_pk"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"pk_columns"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_set"},"value":{"kind":"Variable","name":{"kind":"Name","value":"updateObj"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<UpdateComponentInfoMutation, UpdateComponentInfoMutationVariables>;
@@ -3140,10 +3560,10 @@ export const UpdateBoardVisibilityDocument = {"kind":"Document","definitions":[{
 export const UpdateUserRevisitCountDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"updateUserRevisitCount"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"userId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"lastVisit"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"timestamptz"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"update_users_user_revisits_by_pk"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"pk_columns"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"user_id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"userId"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_inc"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"count"},"value":{"kind":"StringValue","value":"1","block":false}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_set"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"last_visit"},"value":{"kind":"Variable","name":{"kind":"Name","value":"lastVisit"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"count"}},{"kind":"Field","name":{"kind":"Name","value":"user_id"}},{"kind":"Field","name":{"kind":"Name","value":"last_visit"}}]}}]}}]} as unknown as DocumentNode<UpdateUserRevisitCountMutation, UpdateUserRevisitCountMutationVariables>;
 export const MyQueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"MyQuery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"users"},"name":{"kind":"Name","value":"users_user"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<MyQueryQuery, MyQueryQueryVariables>;
 export const GetComponentTypesDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getComponentTypes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"componentTypes"},"name":{"kind":"Name","value":"components_componentType"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"label"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"logo"}},{"kind":"Field","name":{"kind":"Name","value":"width"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"fill"}},{"kind":"Field","name":{"kind":"Name","value":"textColor"}}]}}]}}]} as unknown as DocumentNode<GetComponentTypesQuery, GetComponentTypesQueryVariables>;
-export const GetComponentsForBoardDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getComponentsForBoard"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"components"},"name":{"kind":"Name","value":"components_component"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"boardId"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"children"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"x"}},{"kind":"Field","name":{"kind":"Name","value":"x1"}},{"kind":"Field","name":{"kind":"Name","value":"x2"}},{"kind":"Field","name":{"kind":"Name","value":"y"}},{"kind":"Field","name":{"kind":"Name","value":"y1"}},{"kind":"Field","name":{"kind":"Name","value":"y2"}},{"kind":"Field","name":{"kind":"Name","value":"fill"}},{"kind":"Field","name":{"kind":"Name","value":"width"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"iconStroke"}},{"kind":"Field","name":{"kind":"Name","value":"stroke"}},{"kind":"Field","name":{"kind":"Name","value":"linewidth"}},{"kind":"Field","name":{"kind":"Name","value":"strokeType"}},{"kind":"Field","name":{"kind":"Name","value":"textColor"}}]}}]}}]} as unknown as DocumentNode<GetComponentsForBoardQuery, GetComponentsForBoardQueryVariables>;
+export const GetComponentsForBoardDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getComponentsForBoard"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"components"},"name":{"kind":"Name","value":"components_component"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"boardId"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"objectClass"}},{"kind":"Field","name":{"kind":"Name","value":"children"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"x"}},{"kind":"Field","name":{"kind":"Name","value":"x1"}},{"kind":"Field","name":{"kind":"Name","value":"x2"}},{"kind":"Field","name":{"kind":"Name","value":"y"}},{"kind":"Field","name":{"kind":"Name","value":"y1"}},{"kind":"Field","name":{"kind":"Name","value":"y2"}},{"kind":"Field","name":{"kind":"Name","value":"fill"}},{"kind":"Field","name":{"kind":"Name","value":"width"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"iconStroke"}},{"kind":"Field","name":{"kind":"Name","value":"stroke"}},{"kind":"Field","name":{"kind":"Name","value":"linewidth"}},{"kind":"Field","name":{"kind":"Name","value":"strokeType"}},{"kind":"Field","name":{"kind":"Name","value":"textColor"}}]}}]}}]} as unknown as DocumentNode<GetComponentsForBoardQuery, GetComponentsForBoardQueryVariables>;
 export const GetComponentInfoQueryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getComponentInfoQuery"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"component"},"name":{"kind":"Name","value":"components_component_by_pk"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"width"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"fill"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"stroke"}},{"kind":"Field","name":{"kind":"Name","value":"linewidth"}},{"kind":"Field","name":{"kind":"Name","value":"strokeType"}},{"kind":"Field","name":{"kind":"Name","value":"x"}},{"kind":"Field","name":{"kind":"Name","value":"y"}},{"kind":"Field","name":{"kind":"Name","value":"x1"}},{"kind":"Field","name":{"kind":"Name","value":"y1"}},{"kind":"Field","name":{"kind":"Name","value":"x2"}},{"kind":"Field","name":{"kind":"Name","value":"y2"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"children"}},{"kind":"Field","name":{"kind":"Name","value":"updatedBy"}},{"kind":"Field","name":{"kind":"Name","value":"iconStroke"}},{"kind":"Field","name":{"kind":"Name","value":"textColor"}}]}}]}}]} as unknown as DocumentNode<GetComponentInfoQueryQuery, GetComponentInfoQueryQueryVariables>;
 export const GetBoardComponentsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"getBoardComponents"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"components"},"name":{"kind":"Name","value":"components_component"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"boardId"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}}]}}]}}]} as unknown as DocumentNode<GetBoardComponentsQuery, GetBoardComponentsQueryVariables>;
 export const UserDetailsSubscriptionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"userDetailsSubscription"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"users"},"name":{"kind":"Name","value":"users_user"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"firstName"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<UserDetailsSubscriptionSubscription, UserDetailsSubscriptionSubscriptionVariables>;
 export const GetBoardComponentsSubscriptionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"getBoardComponentsSubscription"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"components"},"name":{"kind":"Name","value":"components_component"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"boardId"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}}]}}]}}]} as unknown as DocumentNode<GetBoardComponentsSubscriptionSubscription, GetBoardComponentsSubscriptionSubscriptionVariables>;
 export const GetComponentInfoSubscriptionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"getComponentInfoSubscription"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"component"},"name":{"kind":"Name","value":"components_component_by_pk"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"width"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"fill"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"stroke"}},{"kind":"Field","name":{"kind":"Name","value":"linewidth"}},{"kind":"Field","name":{"kind":"Name","value":"strokeType"}},{"kind":"Field","name":{"kind":"Name","value":"x"}},{"kind":"Field","name":{"kind":"Name","value":"y"}},{"kind":"Field","name":{"kind":"Name","value":"x1"}},{"kind":"Field","name":{"kind":"Name","value":"y1"}},{"kind":"Field","name":{"kind":"Name","value":"x2"}},{"kind":"Field","name":{"kind":"Name","value":"y2"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"children"}},{"kind":"Field","name":{"kind":"Name","value":"updatedBy"}},{"kind":"Field","name":{"kind":"Name","value":"iconStroke"}},{"kind":"Field","name":{"kind":"Name","value":"textColor"}}]}}]}}]} as unknown as DocumentNode<GetComponentInfoSubscriptionSubscription, GetComponentInfoSubscriptionSubscriptionVariables>;
-export const GetComponentsForBoardSubscriptionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"getComponentsForBoardSubscription"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"components"},"name":{"kind":"Name","value":"components_component"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"boardId"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"children"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"x"}},{"kind":"Field","name":{"kind":"Name","value":"x1"}},{"kind":"Field","name":{"kind":"Name","value":"x2"}},{"kind":"Field","name":{"kind":"Name","value":"y"}},{"kind":"Field","name":{"kind":"Name","value":"y1"}},{"kind":"Field","name":{"kind":"Name","value":"y2"}},{"kind":"Field","name":{"kind":"Name","value":"fill"}},{"kind":"Field","name":{"kind":"Name","value":"width"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"iconStroke"}},{"kind":"Field","name":{"kind":"Name","value":"stroke"}},{"kind":"Field","name":{"kind":"Name","value":"linewidth"}},{"kind":"Field","name":{"kind":"Name","value":"strokeType"}}]}}]}}]} as unknown as DocumentNode<GetComponentsForBoardSubscriptionSubscription, GetComponentsForBoardSubscriptionSubscriptionVariables>;
+export const GetComponentsForBoardSubscriptionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"subscription","name":{"kind":"Name","value":"getComponentsForBoardSubscription"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}},"defaultValue":{"kind":"StringValue","value":"","block":false}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"components"},"name":{"kind":"Name","value":"components_component"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"boardId"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"boardId"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"componentType"}},{"kind":"Field","name":{"kind":"Name","value":"objectClass"}},{"kind":"Field","name":{"kind":"Name","value":"children"}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"x"}},{"kind":"Field","name":{"kind":"Name","value":"x1"}},{"kind":"Field","name":{"kind":"Name","value":"x2"}},{"kind":"Field","name":{"kind":"Name","value":"y"}},{"kind":"Field","name":{"kind":"Name","value":"y1"}},{"kind":"Field","name":{"kind":"Name","value":"y2"}},{"kind":"Field","name":{"kind":"Name","value":"fill"}},{"kind":"Field","name":{"kind":"Name","value":"width"}},{"kind":"Field","name":{"kind":"Name","value":"height"}},{"kind":"Field","name":{"kind":"Name","value":"iconStroke"}},{"kind":"Field","name":{"kind":"Name","value":"stroke"}},{"kind":"Field","name":{"kind":"Name","value":"linewidth"}},{"kind":"Field","name":{"kind":"Name","value":"strokeType"}}]}}]}}]} as unknown as DocumentNode<GetComponentsForBoardSubscriptionSubscription, GetComponentsForBoardSubscriptionSubscriptionVariables>;

--- a/src/schema/queries/index.ts
+++ b/src/schema/queries/index.ts
@@ -52,6 +52,7 @@ export const GET_COMPONENTS_FOR_BOARD_QUERY: TypedDocumentNode<
         ) {
             id
             componentType
+            objectClass
             children
             metadata
             x

--- a/src/schema/subscriptions/index.ts
+++ b/src/schema/subscriptions/index.ts
@@ -76,6 +76,7 @@ export const GET_COMPONENTS_FOR_BOARD_SUBSCRIPTION: TypedDocumentNode<
         ) {
             id
             componentType
+            objectClass
             children
             metadata
             x

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -58,6 +58,37 @@ export interface CameraChangeEvent {
     ty: number
 }
 
+// --- Point clustering (consumer-driven) --------------------------------
+
+/** One point handed to the clustering callback. */
+export interface PointScreenInfo {
+    /** Component id (matches the DOM node's data-component-id). */
+    id: string
+    /** World/surface coordinates. */
+    x: number
+    y: number
+    /** Viewport pixel center of the pin. */
+    screenX: number
+    screenY: number
+    /** metadata.category, if any. */
+    category?: string
+}
+
+/** A cluster the consumer wants craftbase to render in place of its points. */
+export interface Cluster {
+    /** Stable id for React keys / hit-testing. */
+    id: string
+    /** Viewport pixel center where the cluster marker is drawn. */
+    screenX: number
+    screenY: number
+    /** Number to show on the badge. */
+    count: number
+    /** Points absorbed by this cluster — craftbase hides their pins. */
+    pointIds: string[]
+    /** Marker styling: dark (default) or the warm accent variant. */
+    variant?: 'default' | 'warm'
+}
+
 export interface BoardProps {
     /** Fired on ZUI camera updates. See CLAUDE.md "Extension points over forks". */
     onCameraChange?: (event: CameraChangeEvent) => void
@@ -71,6 +102,23 @@ export interface BoardProps {
      * standalone craftbase app is unaffected. Used by craftmaps.
      */
     geoObjectsEnabled?: boolean
+    /**
+     * Opt-in feature flag: cluster nearby points into a single marker. craftbase
+     * only knows the screen camera, not real-world meters, so the actual grouping
+     * is delegated to `clusterPoints` (e.g. craftmaps groups points within 100m
+     * using its map projection). No-op when off or when no callback is supplied.
+     */
+    pointClusteringEnabled?: boolean
+    /**
+     * Consumer-supplied clustering. Given every point's world + screen position
+     * and the current camera, return the clusters to render — craftbase draws a
+     * marker per cluster and hides the absorbed `pointIds`. Required for
+     * clustering to do anything; see `pointClusteringEnabled`.
+     */
+    clusterPoints?: (
+        points: PointScreenInfo[],
+        camera: CameraChangeEvent
+    ) => Cluster[]
 }
 
 // --- Context value ------------------------------------------------------
@@ -181,6 +229,8 @@ export interface BoardContextValue {
     // Consumer extension points (forwarded from BoardProps)
     scaleToDisplay?: BoardProps['scaleToDisplay']
     geoObjectsEnabled?: BoardProps['geoObjectsEnabled']
+    pointClusteringEnabled?: BoardProps['pointClusteringEnabled']
+    clusterPoints?: BoardProps['clusterPoints']
 }
 
 // --- Utility exports ---------------------------------------------------

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -165,7 +165,7 @@ export interface BoardContextValue {
     setTextDrawModeInBoard: (value: boolean) => void
     setRubberModeInBoard: (value: boolean) => void
     cancelPendingElement: () => void
-    enableTextDrawMode: () => void
+    enableTextDrawMode: (componentType?: 'newText' | 'geoText') => void
     createTextAtSurface: (x: number, y: number) => void
     updateLastAddedElement: (element: unknown) => void
 

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -22,6 +22,8 @@ export interface ComponentMetadata {
 export interface ComponentRecord {
     id: string
     componentType: string
+    /** Distinguishes geo objects (point/area/route) from regular shapes. */
+    objectClass?: 'shape' | 'geo'
     x: number
     y: number
     x1: number
@@ -63,6 +65,12 @@ export interface BoardProps {
     renderBackground?: () => ReactNode
     /** Overrides the zoom-readout shown in ZoomControls. */
     scaleToDisplay?: (scale: number) => string
+    /**
+     * Opt-in: surface geo tools (point / area / route) in the toolbar alongside
+     * the regular shape tools. Default off — no-op when omitted, so the
+     * standalone craftbase app is unaffected. Used by craftmaps.
+     */
+    geoObjectsEnabled?: boolean
 }
 
 // --- Context value ------------------------------------------------------
@@ -172,6 +180,7 @@ export interface BoardContextValue {
 
     // Consumer extension points (forwarded from BoardProps)
     scaleToDisplay?: BoardProps['scaleToDisplay']
+    geoObjectsEnabled?: BoardProps['geoObjectsEnabled']
 }
 
 // --- Utility exports ---------------------------------------------------

--- a/src/utils/applyGroupProperty.ts
+++ b/src/utils/applyGroupProperty.ts
@@ -62,7 +62,14 @@ export interface ApplyGroupPropertyDeps {
 }
 
 const ACCEPTS: Record<GroupPropertyKey, Set<string>> = {
-    fill: new Set(['rectangle', 'circle', 'diamond', 'frame', 'newText']),
+    fill: new Set([
+        'rectangle',
+        'circle',
+        'diamond',
+        'frame',
+        'newText',
+        'geoText',
+    ]),
     stroke: new Set([
         'rectangle',
         'circle',
@@ -97,13 +104,32 @@ const ACCEPTS: Record<GroupPropertyKey, Set<string>> = {
         'frame',
         'arrowLine',
         'newText',
+        'geoText',
     ]),
     // rectangle, diamond AND circle all carry text the same way (see
     // applyShapeText / the *-with-text components), so a group text edit
     // must reach every one of them.
-    textColor: new Set(['newText', 'rectangle', 'diamond', 'circle']),
-    textSize: new Set(['newText', 'rectangle', 'diamond', 'circle']),
-    textFontFamily: new Set(['newText', 'rectangle', 'diamond', 'circle']),
+    textColor: new Set([
+        'newText',
+        'geoText',
+        'rectangle',
+        'diamond',
+        'circle',
+    ]),
+    textSize: new Set([
+        'newText',
+        'geoText',
+        'rectangle',
+        'diamond',
+        'circle',
+    ]),
+    textFontFamily: new Set([
+        'newText',
+        'geoText',
+        'rectangle',
+        'diamond',
+        'circle',
+    ]),
 }
 
 function findSceneElement(two: TwoLike, id: string): ShapeLike | undefined {
@@ -316,7 +342,7 @@ export function createApplyGroupProperty(deps: ApplyGroupPropertyDeps) {
             }
 
             if (propertyKey === 'textColor') {
-                if (type === 'newText') {
+                if (type === 'newText' || type === 'geoText') {
                     const sceneTexts = sceneEl
                         ? findTextNodesInside(sceneEl)
                         : []

--- a/src/utils/applyProperty.ts
+++ b/src/utils/applyProperty.ts
@@ -1,4 +1,8 @@
-import { strokeTypeToDashes, clearDashesOnTwoJSShape } from './misc'
+import {
+    strokeTypeToDashes,
+    clearDashesOnTwoJSShape,
+    strokeToAreaFill,
+} from './misc'
 import { getShapeTextNodes } from './canvasUtils'
 
 // Scene-bound selectedComponent shape: `.shape.data`, `.text.data`, and
@@ -168,6 +172,11 @@ export function createApplyProperty(deps: ApplyPropertyDeps) {
         } else if (propertyKey === 'stroke') {
             if (shapeData) shapeData.stroke = value
             if (elementData) elementData.stroke = value
+            // Area fill is a light shade of its stroke — re-derive on the
+            // Two.js path only; fill is never persisted for geo objects.
+            if (elementType === 'area' && shapeData) {
+                shapeData.fill = strokeToAreaFill(value)
+            }
             updateComponentBulkPropertiesInLocalStore(id, { stroke: value })
         } else if (propertyKey === 'linewidth') {
             if (shapeData) shapeData.linewidth = value

--- a/src/utils/applyProperty.ts
+++ b/src/utils/applyProperty.ts
@@ -4,6 +4,12 @@ import {
     strokeToAreaFill,
 } from './misc'
 import { getShapeTextNodes } from './canvasUtils'
+import { buildPointVisual } from '../factory/point'
+import {
+    POINT_CATEGORIES,
+    DEFAULT_POINT_CATEGORY,
+    DEFAULT_GEO_RING_RADIUS,
+} from '../constants/misc'
 
 // Scene-bound selectedComponent shape: `.shape.data`, `.text.data`, and
 // `.group.data.elementData` are scaffolded by newCanvas / element renderers
@@ -105,6 +111,39 @@ export function createApplyProperty(deps: ApplyPropertyDeps) {
 
         const id = selectedComponent?.group?.data?.elementData?.id
         if (!id) return
+
+        // Point category: not a simple shape.data field — re-skin the whole
+        // pin group in place (frozen props mean React won't re-render it) and
+        // persist the new category + derived colors to the store.
+        if (propertyKey === 'pointCategory') {
+            const group = selectedComponent?.group?.data
+            const elementData = group?.elementData
+            if (!group || !elementData) return
+            const cat =
+                POINT_CATEGORIES[value] ??
+                POINT_CATEGORIES[DEFAULT_POINT_CATEGORY]!
+            const existingMeta = elementData.metadata ?? {}
+            const ringRadius = existingMeta.ringRadius ?? DEFAULT_GEO_RING_RADIUS
+            const updatedMeta = {
+                ...existingMeta,
+                category: cat.id,
+                svgIcon: cat.svgIcon,
+            }
+            buildPointVisual(twoJSInstance, group, {
+                category: cat.id,
+                ringRadius,
+            })
+            elementData.metadata = updatedMeta
+            elementData.stroke = cat.bg
+            elementData.fill = cat.bg
+            updateComponentBulkPropertiesInLocalStore(id, {
+                metadata: updatedMeta,
+                stroke: cat.bg,
+                fill: cat.bg,
+            })
+            twoJSInstance?.update()
+            return
+        }
 
         const shapeType = selectedComponent?.shape?.type
         const elementType =

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -92,12 +92,27 @@ export const allColorShades: string[] = [
     '#97A0AF',
 ]
 
+// Fully transparent fill ("none"). Browsers accept rgba() in SVG
+// presentation attributes, so Two.js renders this as no paint.
+export const TRANSPARENT_FILL = 'rgba(0,0,0,0.0)'
+
 export const essentialShades: string[] = [
     '#FFFFFF',
     '#000000',
     '#FF5630',
     '#FFAB00',
     '#36B37E',
+    '#0065FF',
+]
+
+// Fill picker only — transparent ("no fill") first, replacing the green that
+// the shared essentialShades keeps for stroke/text.
+export const fillEssentialShades: string[] = [
+    TRANSPARENT_FILL,
+    '#FFFFFF',
+    '#000000',
+    '#FF5630',
+    '#FFAB00',
     '#0065FF',
 ]
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,6 +11,10 @@ import EraserIcon from '../wireframeAssets/eraser.svg?react'
 import RightArrowIcon from '../assets/right_arrow.svg?react'
 import PanIcon from '../assets/pan.svg?react'
 
+import PinIcon from '../wireframeAssets/pin.svg?react'
+import PolygonIcon from '../wireframeAssets/polygon.svg?react'
+import PolylineIcon from '../wireframeAssets/polyline.svg?react'
+
 type SvgComponent = FunctionComponent<SVGProps<SVGSVGElement>>
 
 export const color_blue = '#0052CC'
@@ -215,6 +219,35 @@ export const staticPrimaryElementData: PrimarySection[] = [
                 drawerData: [],
             },
         ],
+    },
+]
+
+// Geo tools (point / area / route). Surfaced in the toolbar only when the
+// consumer passes `geoObjectsEnabled` — appended alongside the shape tools.
+export const geoElementData: PrimaryElement[] = [
+    {
+        elementName: 'point',
+        elementDisplayName: 'Point',
+        elementIcon: PinIcon,
+        hasDrawer: false,
+        noAction: false,
+        drawerData: [],
+    },
+    {
+        elementName: 'area',
+        elementDisplayName: 'Area',
+        elementIcon: PolygonIcon,
+        hasDrawer: false,
+        noAction: false,
+        drawerData: [],
+    },
+    {
+        elementName: 'route',
+        elementDisplayName: 'Route',
+        elementIcon: PolylineIcon,
+        hasDrawer: false,
+        noAction: false,
+        drawerData: [],
     },
 ]
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -249,6 +249,16 @@ export const geoElementData: PrimaryElement[] = [
         noAction: false,
         drawerData: [],
     },
+    {
+        // Zoom-resistant text for maps — counter-scales on zoom like a point
+        // pin (see geoText.tsx). Replaces the standard Text tool in geo mode.
+        elementName: 'geoText',
+        elementDisplayName: 'Text',
+        elementIcon: TextIcon,
+        hasDrawer: false,
+        noAction: false,
+        drawerData: [],
+    },
 ]
 
 export interface TextSizeEntry {

--- a/src/utils/counterScale.ts
+++ b/src/utils/counterScale.ts
@@ -1,0 +1,19 @@
+// Counter-scale (zoom-resistance) for canvas elements that should stay legible
+// as the world zooms out — most notably geo "point" pins.
+//
+// pinScale = 1 / (zuiScale ^ resist)
+//   resist = 0   → element is fully fixed on screen (ignores zoom completely)
+//   resist = 0.5 → "half resistant" — shrinks much slower than the world
+//   resist = 1   → element scales exactly with the world (no counter-scaling)
+//
+// Reference: the standalone prototype in point_two.js.
+
+import { DEFAULT_GEO_RESIST } from '../constants/misc'
+
+export function computeCounterScale(
+    zuiScale: number,
+    resist: number = DEFAULT_GEO_RESIST
+): number {
+    if (!Number.isFinite(zuiScale) || zuiScale <= 0) return 1
+    return 1 / Math.pow(zuiScale, resist)
+}

--- a/src/utils/groupInspect.ts
+++ b/src/utils/groupInspect.ts
@@ -15,6 +15,7 @@ type ComponentType =
     | 'diamond'
     | 'frame'
     | 'newText'
+    | 'geoText'
     | 'arrowLine'
     | 'pencil'
     | 'divider'
@@ -71,7 +72,14 @@ interface DefaultsForInspect {
 // Mirrors the acceptance map in applyGroupProperty.ts. Kept in sync manually
 // — this is small and changes rarely.
 const ACCEPTS: Record<InspectableProperty, Set<string>> = {
-    fill: new Set(['rectangle', 'circle', 'diamond', 'frame', 'newText']),
+    fill: new Set([
+        'rectangle',
+        'circle',
+        'diamond',
+        'frame',
+        'newText',
+        'geoText',
+    ]),
     stroke: new Set([
         'rectangle',
         'circle',
@@ -104,10 +112,29 @@ const ACCEPTS: Record<InspectableProperty, Set<string>> = {
         'frame',
         'arrowLine',
         'newText',
+        'geoText',
     ]),
-    textColor: new Set(['newText', 'rectangle', 'diamond', 'circle']),
-    textSize: new Set(['newText', 'rectangle', 'diamond', 'circle']),
-    textFontFamily: new Set(['newText', 'rectangle', 'diamond', 'circle']),
+    textColor: new Set([
+        'newText',
+        'geoText',
+        'rectangle',
+        'diamond',
+        'circle',
+    ]),
+    textSize: new Set([
+        'newText',
+        'geoText',
+        'rectangle',
+        'diamond',
+        'circle',
+    ]),
+    textFontFamily: new Set([
+        'newText',
+        'geoText',
+        'rectangle',
+        'diamond',
+        'circle',
+    ]),
 }
 
 function readChildValue(child: ChildEntry, key: InspectableProperty): unknown {
@@ -128,7 +155,11 @@ function readChildValue(child: ChildEntry, key: InspectableProperty): unknown {
         case 'opacity':
             return meta?.opacity ?? 1
         case 'textColor':
-            if (child.componentType === 'newText') return child.textColor
+            if (
+                child.componentType === 'newText' ||
+                child.componentType === 'geoText'
+            )
+                return child.textColor
             return meta?.textFill
         case 'textSize':
             return meta?.textFontSize

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -6,6 +6,44 @@ export function strokeTypeToDashes(strokeType: string | null | undefined): numbe
     return []
 }
 
+// Area (closed geo polygon) fill is always a light shade of its stroke: the
+// stroke color at 0.7 opacity. Never stored — re-derived on every render and on
+// every stroke edit. Handles #rgb / #rrggbb / rgb() / rgba(); falls back to the
+// input (so 'transparent' / named colors pass through unchanged).
+const AREA_FILL_ALPHA = 0.7
+
+export function strokeToAreaFill(
+    stroke: string | null | undefined,
+    alpha: number = AREA_FILL_ALPHA
+): string {
+    if (!stroke) return `rgba(0,0,0,${alpha})`
+    const hex = stroke.trim()
+
+    // #rgb or #rrggbb
+    const shortHex = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i.exec(hex)
+    const longHex = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex)
+    if (shortHex) {
+        const r = parseInt(shortHex[1]! + shortHex[1]!, 16)
+        const g = parseInt(shortHex[2]! + shortHex[2]!, 16)
+        const b = parseInt(shortHex[3]! + shortHex[3]!, 16)
+        return `rgba(${r},${g},${b},${alpha})`
+    }
+    if (longHex) {
+        const r = parseInt(longHex[1]!, 16)
+        const g = parseInt(longHex[2]!, 16)
+        const b = parseInt(longHex[3]!, 16)
+        return `rgba(${r},${g},${b},${alpha})`
+    }
+
+    // rgb(r,g,b) or rgba(r,g,b,a) → override alpha
+    const rgb = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i.exec(hex)
+    if (rgb) {
+        return `rgba(${rgb[1]},${rgb[2]},${rgb[3]},${alpha})`
+    }
+
+    return stroke
+}
+
 // Two.js SVG renderer only sets stroke-dasharray when dashes.length > 0,
 // but never removes the attribute when dashes = []. Call this after setting
 // dashes = [] on a shape to ensure the SVG attribute is cleared.

--- a/src/views/Board/board.tsx
+++ b/src/views/Board/board.tsx
@@ -62,6 +62,7 @@ import {
     GEO_DRAW_TYPE_KEY,
     GEO_DRAW_PROPS_KEY,
     GEO_POINT_PLACE_MODE_KEY,
+    DEFAULT_GEO_RESIST,
 } from '../../constants/misc'
 import { useDrawingModes } from '../../hooks/useDrawingModes'
 import { useElementDefaults } from '../../hooks/useElementDefaults'
@@ -567,7 +568,10 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
     const buildTextShapeData = (
         id: string,
         x: number,
-        y: number
+        y: number,
+        // 'newText' is the standard whiteboard text; 'geoText' is the
+        // zoom-resistant map variant (counter-scales like a point pin).
+        componentType: 'newText' | 'geoText' = 'newText'
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ): any | null => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -596,7 +600,10 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
             (sizesMap as any)[defaultTextSize] ?? typeItem.metadata?.fontSize
         return {
             id,
-            componentType: 'newText',
+            componentType,
+            // geoText is anchored to the map, so flag it geo (mirrors point/
+            // area/route) and seed the counter-scale resist it reads on mount.
+            ...(componentType === 'geoText' && { objectClass: 'geo' }),
             linewidth: defaultLinewidth,
             strokeType: defaultStrokeType,
             children: {},
@@ -605,6 +612,9 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
                 ...(fontSizePx !== undefined && { fontSize: fontSizePx }),
                 ...(defaultTextFontFamily && {
                     textFontFamily: defaultTextFontFamily,
+                }),
+                ...(componentType === 'geoText' && {
+                    resist: DEFAULT_GEO_RESIST,
                 }),
                 opacity: defaultOpacity ?? 1,
             },
@@ -622,18 +632,20 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
 
     // One-shot text-draw mode: cursor → crosshair, next mousedown on canvas
     // places the pending text element via SCENARIO_TEXT_DRAW in newCanvas.js.
-    const enableTextDrawMode = () => {
+    const enableTextDrawMode = (
+        componentType: 'newText' | 'geoText' = 'newText'
+    ) => {
         togglePencilMode(false)
         togglePointer(false)
         const id = generateUUID()
-        const shapeData = buildTextShapeData(id, -9999, -9999)
+        const shapeData = buildTextShapeData(id, -9999, -9999, componentType)
         if (!shapeData) return
         updateLastAddedElement(shapeData)
         setRootCursor('crosshair')
         localStorage.setItem(TEXT_DRAW_MODE_KEY, 'true')
         localStorage.setItem(LAST_ADDED_ELEMENT_ID_KEY, id)
         setTextDrawModeInBoard(true)
-        addToLocalComponentStore(id, 'newText', shapeData)
+        addToLocalComponentStore(id, componentType, shapeData)
     }
 
     // Place a text element at the given surface coords and immediately open

--- a/src/views/Board/board.tsx
+++ b/src/views/Board/board.tsx
@@ -58,6 +58,10 @@ import {
     MOBILE_VIEWPORT_KEY_PREFIX,
     VIEWPORT_TTL_MS,
     DEFAULT_TEXT_SIZE,
+    GEO_DRAW_MODE_KEY,
+    GEO_DRAW_TYPE_KEY,
+    GEO_DRAW_PROPS_KEY,
+    GEO_POINT_PLACE_MODE_KEY,
 } from '../../constants/misc'
 import { useDrawingModes } from '../../hooks/useDrawingModes'
 import { useElementDefaults } from '../../hooks/useElementDefaults'
@@ -1143,6 +1147,13 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
         localStorage.removeItem(TEXT_DRAW_MODE_KEY)
         localStorage.removeItem(PENDING_SHAPE_TYPE_KEY)
         localStorage.removeItem(PENDING_SHAPE_PROPS_KEY)
+        // Abort any in-progress geo draw (multi-click area/route, point place)
+        // and tell the canvas to drop its preview vertices.
+        localStorage.removeItem(GEO_DRAW_MODE_KEY)
+        localStorage.removeItem(GEO_DRAW_TYPE_KEY)
+        localStorage.removeItem(GEO_DRAW_PROPS_KEY)
+        localStorage.removeItem(GEO_POINT_PLACE_MODE_KEY)
+        window.dispatchEvent(new CustomEvent('cancelGeoDraw', {}))
         setIsArrowDrawMode(false)
         setIsTextDrawMode(false)
         // Detach selectionController so its hover listener stops overriding the cursor
@@ -1224,6 +1235,7 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
 
     const contextValueForSidebar = {
         scaleToDisplay: props.scaleToDisplay,
+        geoObjectsEnabled: props.geoObjectsEnabled,
         boardId,
         isPersisted,
         persistBoard,

--- a/src/views/Board/board.tsx
+++ b/src/views/Board/board.tsx
@@ -2,8 +2,6 @@ import React, {
     useState,
     useEffect,
     useRef,
-    useContext,
-    createContext,
     type ReactNode,
 } from 'react'
 import { useMutation, useQuery } from '@apollo/client'
@@ -27,6 +25,8 @@ import Canvas from '../../newCanvas'
 import ZoomControls from '../../components/ZoomControls'
 import Sidebar from '../../components/sidebar/primary'
 import ElementPropertiesToolbar from '../../components/sidebar/elementProperties'
+import PointTooltip from '../../components/elements/pointTooltip'
+import ClusterLayer from '../../components/elements/clusterLayer'
 import controlsIcon from '../../assets/controls.svg'
 import PermissionErrorModal from '../../components/modals/PermissionErrorModal'
 import StorageLimitModal from '../../components/modals/StorageLimitModal'
@@ -80,10 +80,12 @@ import type {
     ComponentStore,
     CameraChangeEvent,
 } from '../../types/board'
+import { BoardContext, useBoardContext } from './boardContext'
 
-export const BoardContext = createContext<BoardContextValue | undefined>(
-    undefined
-)
+// Re-exported so existing importers (`from '.../views/Board/board'`) and the
+// public lib.ts surface keep working — the canonical definition now lives in
+// the stable boardContext module (see the comment there for the HMR rationale).
+export { BoardContext, useBoardContext }
 
 // Strips __typename fields injected by Apollo before sending data back to Hasura
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -295,8 +297,15 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
     // Clear stale interaction flags from localStorage on mount so a page refresh
     // never triggers SCENARIO_DRAW_SHAPE / SCENARIO_ARROW_DRAW / etc. on the
     // first mousedown. These keys are only meaningful within a single page session.
+    //
+    // This parent effect runs AFTER the child shapesToolbar effect that sets the
+    // pan default, so the sweep above (which clears PAN_MODE_KEY) would otherwise
+    // wipe it out — leaving pan highlighted but inert. Re-activate it here so the
+    // pan default actually takes effect when geo objects are enabled.
     useEffect(() => {
         clearDrawModesFromStorage()
+        if (props.geoObjectsEnabled) togglePanMode(true)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
     // Sweep viewport entries older than VIEWPORT_TTL_MS or missing savedAt.
@@ -1236,6 +1245,8 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
     const contextValueForSidebar = {
         scaleToDisplay: props.scaleToDisplay,
         geoObjectsEnabled: props.geoObjectsEnabled,
+        pointClusteringEnabled: props.pointClusteringEnabled,
+        clusterPoints: props.clusterPoints,
         boardId,
         isPersisted,
         persistBoard,
@@ -1356,6 +1367,8 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
                         onCameraChange={props.onCameraChange}
                         renderBackground={props.renderBackground}
                     />
+                    <PointTooltip />
+                    <ClusterLayer />
                     {!isMobile && <ZoomControls />}
                 </div>
             </BoardContext.Provider>
@@ -1381,14 +1394,6 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
             />
         </>
     )
-}
-
-export const useBoardContext = (): BoardContextValue => {
-    const ctx = useContext(BoardContext)
-    if (!ctx) {
-        throw new Error('useBoardContext must be called inside <Board />')
-    }
-    return ctx
 }
 
 export default BoardViewPage

--- a/src/views/Board/boardContext.ts
+++ b/src/views/Board/boardContext.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react'
+import type { BoardContextValue } from '../../types/board'
+
+// BoardContext lives in its own leaf module — deliberately separate from the
+// large, frequently-edited board.tsx. React context identity must be stable
+// across the whole app, but board.tsx (and everything it statically imports)
+// gets re-evaluated on every HMR update, which would mint a NEW context object
+// each time. Element components are lazy-loaded (React.lazy + import.meta.glob
+// in newCanvas) through a separate module graph, so after a board.tsx hot-update
+// they'd keep reading the OLD context while the Provider supplies the NEW one —
+// surfacing as "useBoardContext must be called inside <Board />" even though the
+// component is rendered under the Provider. Keeping the context here (no
+// changing deps → never hot-updated) guarantees a single shared identity.
+export const BoardContext = createContext<BoardContextValue | undefined>(
+    undefined
+)
+
+export const useBoardContext = (): BoardContextValue => {
+    const ctx = useContext(BoardContext)
+    if (!ctx) {
+        throw new Error('useBoardContext must be called inside <Board />')
+    }
+    return ctx
+}

--- a/src/wireframeAssets/pin.svg
+++ b/src/wireframeAssets/pin.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" color="currentColor"> <title>Point</title> <path d="M12 21s7-7.16 7-12a7 7 0 1 0-14 0c0 4.84 7 12 7 12z"/> <circle cx="12" cy="9" r="2.5"/> </svg>

--- a/src/wireframeAssets/polygon.svg
+++ b/src/wireframeAssets/polygon.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" color="currentColor"> <title>Area</title> <polygon points="12 3 20 9 17 19 7 19 4 9"/> </svg>

--- a/src/wireframeAssets/polyline.svg
+++ b/src/wireframeAssets/polyline.svg
@@ -1,0 +1,1 @@
+<svg role="img" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" color="currentColor"> <title>Route</title> <polyline points="3 18 9 8 14 14 21 5"/> </svg>


### PR DESCRIPTION
Add geo based objects for craftmaps as consumer. These objects are tailor made for another project (craftmaps) which will be consumer of craftbase's generic canvas component.
