### PR TITLE
Perf testing 12 07

### DIFF
--- a/.claude/context/font-guide.md
+++ b/.claude/context/font-guide.md
@@ -2,42 +2,54 @@
 
 ## Font Stack
 
-| Font           | Role                                     | Import                    |
-| -------------- | ---------------------------------------- | ------------------------- |
-| **Geist**      | UI chrome, all app interface text        | Google Fonts / Vercel CDN |
-| **Geist Mono** | Numeric values, coordinates, hex codes   | Google Fonts / Vercel CDN |
-| **Fraunces**   | Branding, headings, display text         | Google Fonts              |
-| **Caveat**     | Canvas sketch elements (user-selectable) | Google Fonts              |
+| Font             | Role                                                          | Import                    |
+| ---------------- | ------------------------------------------------------------- | ------------------------- |
+| **Geist**        | UI chrome, all app interface text                             | Google Fonts / Vercel CDN |
+| **Geist Mono**   | Numeric values, coordinates, hex codes                        | Google Fonts / Vercel CDN |
+| **Fraunces**     | Branding, headings, display text                              | Google Fonts              |
+| **Caveat Brush** | Canvas text — the **default** for anything drawn on the board | Google Fonts              |
+| **Caveat**       | Canvas text — alternate, user-selectable                      | Google Fonts              |
+
+> **Canvas ≠ app chrome.** The app UI defaults to Geist; the _canvas_ defaults to
+> Caveat Brush. Don't collapse the two — see §5.
 
 ---
 
 ## Import (Google Fonts)
 
-Add this to your root `index.html` or global CSS file:
+This is the live link in `index.html` — keep it in sync when adding a family:
 
 ```html
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
-    href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,600;1,9..144,400&family=Caveat:wght@400;600&family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Caveat:wght@700&family=Fraunces:ital,opsz,wght@0,9..144,100..900;1,9..144,100..900&family=Geist+Mono:wght@100..900&family=Geist:wght@100..900&family=Caveat+Brush&display=swap"
     rel="stylesheet"
 />
 ```
+
+> **Caveat Brush ships regular (400) only** — it has no bold cut. Asking for
+> bold canvas text gets browser-synthesized fake bold, not a real weight.
 
 ---
 
 ## CSS Variables (Design Tokens)
 
-Define these in your `:root` or Tailwind config:
+Defined in `src/App.css`:
 
 ```css
 :root {
     --font-ui: 'Geist', system-ui, sans-serif;
     --font-mono: 'Geist Mono', monospace;
     --font-display: 'Fraunces', Georgia, serif;
-    --font-sketch: 'Caveat', cursive;
+    --font-sketch: 'Caveat Brush', cursive;
+    --font-caveat-brush: 'Caveat Brush', cursive;
 }
 ```
+
+`--font-sketch` (the _role_) and `--font-caveat-brush` (the _family_) currently
+resolve to the same stack. Keep both named — the role token is what moves if the
+canvas default ever changes again.
 
 ### Tailwind Config (`tailwind.config.js`)
 
@@ -46,9 +58,24 @@ fontFamily: {
     ui:      ['Geist', 'system-ui', 'sans-serif'],
     mono:    ['Geist Mono', 'monospace'],
     display: ['Fraunces', 'Georgia', 'serif'],
-    sketch:  ['Caveat', 'cursive'],
+    sketch:  ['Caveat Brush', 'cursive'],
 },
 ```
+
+### The canvas default lives in TypeScript, not CSS
+
+Canvas text is rendered by Two.js (`twoText.family = …`), so it reads a JS
+constant rather than a CSS variable:
+
+```ts
+// src/constants/misc.ts — single source of truth
+export const DEFAULT_TEXT_FONT_FAMILY = 'Caveat Brush'
+```
+
+Every canvas-text fallback is written `family || DEFAULT_TEXT_FONT_FAMILY`, and
+`useElementDefaults` seeds `defaultTextFontFamily` from it. **Changing the canvas
+default means changing this constant** — then keeping `--font-sketch`, the
+Tailwind `sketch` token, and the `index.html` link in step with it.
 
 ---
 
@@ -79,7 +106,7 @@ button {
 ;<div className="font-ui text-sm font-medium">Stroke Width</div>
 ```
 
-> **Rule:** Never use Fraunces, Geist Mono, or Caveat anywhere inside the toolbar or sidebar. Geist only.
+> **Rule:** Never use Fraunces, Geist Mono, Caveat, or Caveat Brush anywhere inside the toolbar or sidebar. Geist only.
 
 ---
 
@@ -171,44 +198,47 @@ button {
 
 ### 5. Canvas — Default Text Elements
 
-**Font:** Geist  
-**When:** Text boxes, sticky notes, and labels that users place on the canvas by default.
+**Font:** Caveat Brush  
+**When:** Anything the user draws on the board — standalone text elements, text
+typed inside a shape, arrow labels. Also the welcome sketch (`welcomeSketch.ts`
+sets `SKETCH_FONT = DEFAULT_TEXT_FONT_FAMILY`).
 
-```css
-/* CSS */
-.canvas-text-element {
-    font-family: var(--font-ui);
-    font-size: 14px;
-    font-weight: 400;
-}
+Canvas text isn't styled by CSS classes — Two.js sets the family on the text node
+directly, so the default flows from the constant:
+
+```ts
+import { DEFAULT_TEXT_FONT_FAMILY } from '../constants/misc'
+
+twoText.family = textFontFamily ?? DEFAULT_TEXT_FONT_FAMILY // 'Caveat Brush'
 ```
 
-> Keep canvas defaults neutral so the user's content stays in focus. Geist is clean and readable at any zoom level.
+> **Why handwritten by default?** The canvas is a sketching surface — a
+> handwritten face signals "this is a draft, move things around" in a way a
+> neutral UI font doesn't. That's a deliberate product choice, not an oversight:
+> the canvas and the app chrome are meant to feel like different materials.
 
 ---
 
-### 6. Canvas — Sketch / Handwritten Style (User-selectable)
+### 6. Canvas — Switching Fonts (User-selectable)
 
-**Font:** Caveat  
-**When:** User explicitly switches a text element to "sketch" style. Great for annotations, arrow labels, sticky notes in brainstorm mode.
+Users change the font of a selected element from the properties panel
+(`elementProperties.tsx`). The picker currently offers exactly three:
 
-```css
-/* CSS */
-.canvas-text-element.sketch {
-    font-family: var(--font-sketch);
-    font-size: 16px; /* Caveat needs slightly larger size to read well */
-    font-weight: 400;
-}
-```
+| Option           | Feel                                            |
+| ---------------- | ----------------------------------------------- |
+| **Caveat Brush** | Default — brushy, higher-contrast handwriting   |
+| **Caveat**       | Lighter, more legible handwriting               |
+| **Geist**        | Neutral — for diagrams that must read as formal |
 
-```jsx
-{
-    /* Tailwind */
-}
-;<span className="font-sketch text-base">This is a sketch annotation</span>
-```
+Picking a font is **universal, not per-element**: `board.tsx` calls
+`setDefaultTextFontFamily(fontFamily)` on change, so every element created
+afterward inherits it. Changing it also triggers
+`reflowShapeTextAfterStyleChange` — families have different metrics, so shape
+text must re-wrap and the shape may need to grow.
 
-> **Note:** Caveat should never appear in the app UI. It's a canvas-only, user-triggered font. Treat it like a tool, not a default.
+> Existing elements store their family in `metadata.textFontFamily`. Changing
+> `DEFAULT_TEXT_FONT_FAMILY` is **not** retroactive — saved elements keep the
+> family they were created with.
 
 ---
 
@@ -232,27 +262,29 @@ button {
 
 ## Quick Reference Cheatsheet
 
-| Area                      | Font       | Weight    | Style  |
-| ------------------------- | ---------- | --------- | ------ |
-| Toolbar, sidebar, menus   | Geist      | 400 / 500 | Normal |
-| Input fields, labels      | Geist      | 400       | Normal |
-| Coordinates, dimensions   | Geist Mono | 400       | Normal |
-| Hex colors, percentages   | Geist Mono | 400       | Normal |
-| Zoom level, status bar    | Geist Mono | 400 / 500 | Normal |
-| Logo / wordmark           | Fraunces   | 600       | Normal |
-| Landing page hero         | Fraunces   | 600       | Normal |
-| App modal / panel titles  | Fraunces   | 400       | Normal |
-| Empty states, microcopy   | Fraunces   | 400       | Italic |
-| Canvas text (default)     | Geist      | 400       | Normal |
-| Canvas text (sketch mode) | Caveat     | 400       | Normal |
+| Area                     | Font           | Weight    | Style  |
+| ------------------------ | -------------- | --------- | ------ |
+| Toolbar, sidebar, menus  | Geist          | 400 / 500 | Normal |
+| Input fields, labels     | Geist          | 400       | Normal |
+| Coordinates, dimensions  | Geist Mono     | 400       | Normal |
+| Hex colors, percentages  | Geist Mono     | 400       | Normal |
+| Zoom level, status bar   | Geist Mono     | 400 / 500 | Normal |
+| Logo / wordmark          | Fraunces       | 600       | Normal |
+| Landing page hero        | Fraunces       | 600       | Normal |
+| App modal / panel titles | Fraunces       | 400       | Normal |
+| Empty states, microcopy  | Fraunces       | 400       | Italic |
+| Canvas text (default)    | Caveat Brush   | 400       | Normal |
+| Canvas text (alternates) | Caveat / Geist | 400       | Normal |
 
 ---
 
 ## What to Avoid
 
-- **Don't mix Fraunces and Caveat** in the same area — they're both expressive and will clash.
-- **Don't use Caveat in UI chrome** — it signals "rough draft" which is wrong for navigation and controls.
+- **Don't mix Fraunces and the Caveats** in the same area — they're both expressive and will clash.
+- **Don't use Caveat or Caveat Brush in UI chrome** — they signal "rough draft", which is wrong for navigation and controls. Handwritten faces are canvas-only.
 - **Don't use Geist for branding** — it's invisible by design, which is a liability for identity.
+- **Don't hard-code `'Caveat Brush'` at a call site** — reference `DEFAULT_TEXT_FONT_FAMILY` so the default stays swappable in one place.
+- **Don't ask Caveat Brush for bold** — it has no bold cut; you'll get fake bold.
 - **Don't use Fraunces below 14px** — its optical sizing works best at display and heading sizes.
 - **Don't use Geist Mono for labels or headings** — it's data-only; used elsewhere it feels cold and technical.
 - **Don't use Geist Mono on the canvas** — canvas text should feel human, not like a terminal.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ yarn test        # unit tests (vitest)
 yarn test:e2e    # end-to-end tests (playwright)
 ```
 
+## Perf test
+
+Before 0.8.3
+
+```
+     1200 mixed elems (0.97 MB) | settle   3512 ms | blocking   2043 ms | svg nodes 7817 | selectable nodes 1200
+     3000 mixed elems (2.43 MB) | settle  15629 ms | blocking  14242 ms | svg nodes 19517 | selectable nodes 3000
+```
+
 ## Contributing
 
 Issues and pull requests are welcome — features, suggestions, and bug reports all count. It's a weekend project, so I appreciate the patience and the company.

--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 :root {
     --font-ui: 'Geist', system-ui, sans-serif;
     --font-display: 'Fraunces', Georgia, serif;
-    --font-sketch: 'Caveat';
+    --font-sketch: 'Caveat Brush', cursive;
     --font-mono: 'Geist Mono', monospace;
     --font-caveat-brush: 'Caveat Brush', cursive;
 

--- a/src/canvas/selectionController.ts
+++ b/src/canvas/selectionController.ts
@@ -659,6 +659,23 @@ export default class SelectionController {
         this.two.update()
     }
 
+    // For CSS-transform move-drags: hand back the selection-chrome SVG node and
+    // its base position so the caller can translate the box in lockstep with the
+    // element (via a CSS transform) without a full-scene re-render. Returns null
+    // when nothing is selected or the chrome isn't mounted yet. `group` guards
+    // that the chrome actually belongs to the element being dragged.
+    getChromeDragHandle(
+        group: GroupLike
+    ): { node: SVGGraphicsElement; baseX: number; baseY: number } | null {
+        if (!this.currentGroup || this.currentGroup !== group) return null
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const node = (this.ui as any)?._renderer?.elem as
+            | SVGGraphicsElement
+            | undefined
+        if (!node) return null
+        return { node, baseX: this.ui.position.x, baseY: this.ui.position.y }
+    }
+
     syncToTarget(): void {
         if (!this.currentGroup || !this.currentShape || !this.currentAdapter)
             return

--- a/src/components/dev/PerfOverlay.tsx
+++ b/src/components/dev/PerfOverlay.tsx
@@ -1,0 +1,254 @@
+// Dev-only performance overlay for the canvas.
+//
+// Purpose: make the pan/zoom paint cost VISIBLE and let it be validated on a
+// real GPU (headless Chromium can't reproduce it — it uses a software
+// rasteriser). Shows live FPS, the worst frame gap over the last window (the
+// stutter metric), the total element count, how many are currently
+// viewport-culled, and the live zoom. Includes a viewport-culling toggle and a
+// "seed N shapes" button so a dense board can be reproduced on demand.
+//
+// Reads the dev-only `window.__cbTwo` handle exposed by newCanvas. Rendered
+// only under import.meta.env.DEV, so it ships in no production bundle.
+
+import { useEffect, useRef, useState } from 'react'
+import type { ReactElement } from 'react'
+import { DRAFT_STORAGE_KEY } from '../../constants/misc'
+import {
+    getViewportCullingEnabled,
+    setViewportCullingEnabled,
+    subscribeViewportCullingEnabled,
+} from '../../utils/featureFlags'
+import { CULLED_FLAG } from '../../utils/viewportCulling'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Two = any
+
+function getTwo(): Two | null {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (window as any).__cbTwo ?? null
+}
+
+// Count total content elements + how many are currently culled.
+function countElements(two: Two): { total: number; culled: number } {
+    let total = 0
+    let culled = 0
+    const scene = two?.scene
+    if (!scene) return { total, culled }
+    for (const child of scene.children) {
+        if (!child?.elementData?.id) continue
+        total++
+        if (child[CULLED_FLAG]) culled++
+    }
+    return { total, culled }
+}
+
+// Seed N simple shapes into a local draft and reload — mirrors the real
+// board-load path (draft restore), which is exactly the code we want to stress.
+function seedShapes(n: number): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const components: Record<string, any> = {}
+    const types = ['rectangle', 'circle', 'line']
+    const spread = Math.ceil(Math.sqrt(n)) * 180
+    for (let i = 0; i < n; i++) {
+        const type = types[i % 3]
+        const x = Math.round(Math.random() * spread - spread / 2)
+        const y = Math.round(Math.random() * spread - spread / 2)
+        const id = `perf-${i}-${Math.random().toString(36).slice(2, 8)}`
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const base: any = {
+            id,
+            componentType: type,
+            x,
+            y,
+            width: 120,
+            height: 120,
+            fill: '#f4f4f2',
+            stroke: '#1c1c1c',
+            linewidth: 2,
+            strokeType: 'solid',
+            boardId: 'perf-board',
+        }
+        if (type === 'line') {
+            base.x1 = x
+            base.y1 = y
+            base.x2 = x + 100
+            base.y2 = y + 60
+        }
+        components[id] = base
+    }
+    localStorage.setItem(
+        DRAFT_STORAGE_KEY,
+        JSON.stringify({
+            boardId: 'perf-board',
+            components,
+            timestamp: Date.now(),
+        })
+    )
+    window.location.reload()
+}
+
+const PerfOverlay = (): ReactElement => {
+    const [fps, setFps] = useState(0)
+    const [maxGap, setMaxGap] = useState(0)
+    const [total, setTotal] = useState(0)
+    const [culled, setCulled] = useState(0)
+    // Stored as the raw scale multiplier and shown as "1.00×" (not "100%") so
+    // the overlay never collides with the ZoomControls "N%" readout that e2e
+    // asserts on via an exact-text match.
+    const [zoom, setZoom] = useState(1)
+    const [culling, setCulling] = useState(getViewportCullingEnabled())
+    const [seedN, setSeedN] = useState(2000)
+
+    // Frame-rate + worst-frame-gap sampler. One rAF loop; publishes to state
+    // twice a second so React churn doesn't itself perturb the measurement.
+    const frames = useRef(0)
+    const windowMaxGap = useRef(0)
+    const lastFrame = useRef(0)
+    const lastPublish = useRef(performance.now())
+
+    useEffect(() => {
+        let raf = 0
+        const tick = (t: number): void => {
+            frames.current++
+            if (lastFrame.current) {
+                const gap = t - lastFrame.current
+                if (gap > windowMaxGap.current) windowMaxGap.current = gap
+            }
+            lastFrame.current = t
+
+            const now = performance.now()
+            const elapsed = now - lastPublish.current
+            if (elapsed >= 500) {
+                setFps(Math.round((frames.current * 1000) / elapsed))
+                setMaxGap(Math.round(windowMaxGap.current))
+                const two = getTwo()
+                if (two) {
+                    const c = countElements(two)
+                    setTotal(c.total)
+                    setCulled(c.culled)
+                    setZoom(two.scene.scale || 1)
+                }
+                frames.current = 0
+                windowMaxGap.current = 0
+                lastPublish.current = now
+            }
+            raf = requestAnimationFrame(tick)
+        }
+        raf = requestAnimationFrame(tick)
+        return () => cancelAnimationFrame(raf)
+    }, [])
+
+    useEffect(() => subscribeViewportCullingEnabled(setCulling), [])
+
+    const gapBad = maxGap > 20 // > ~1.2 frames == a dropped frame this window
+
+    return (
+        <div
+            style={{
+                position: 'fixed',
+                top: 10,
+                right: 10,
+                zIndex: 10000,
+                background: 'rgba(0,0,0,0.78)',
+                color: '#fff',
+                font: '12px/1.5 monospace',
+                padding: '8px 10px',
+                borderRadius: 8,
+                minWidth: 190,
+                pointerEvents: 'auto',
+                userSelect: 'none',
+            }}
+        >
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span>FPS</span>
+                <strong style={{ color: fps >= 55 ? '#7CFC7C' : '#FFB84D' }}>
+                    {fps}
+                </strong>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span>worst frame</span>
+                <strong style={{ color: gapBad ? '#FF7A7A' : '#7CFC7C' }}>
+                    {maxGap}ms
+                </strong>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span>zoom</span>
+                <span>{zoom.toFixed(2)}×</span>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span>elements</span>
+                <span>{total}</span>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                <span>culled</span>
+                <span>
+                    {culled}
+                    {total > 0 ? ` (${Math.round((culled / total) * 100)}%)` : ''}
+                </span>
+            </div>
+
+            <label
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    marginTop: 8,
+                    cursor: 'pointer',
+                }}
+            >
+                <input
+                    type="checkbox"
+                    checked={culling}
+                    onChange={(e) =>
+                        setViewportCullingEnabled(e.target.checked)
+                    }
+                />
+                viewport culling
+            </label>
+
+            <div
+                style={{
+                    display: 'flex',
+                    gap: 4,
+                    marginTop: 8,
+                    alignItems: 'center',
+                }}
+            >
+                <input
+                    type="number"
+                    value={seedN}
+                    min={0}
+                    step={500}
+                    onChange={(e) => setSeedN(Number(e.target.value) || 0)}
+                    style={{
+                        width: 64,
+                        background: '#222',
+                        color: '#fff',
+                        border: '1px solid #555',
+                        borderRadius: 4,
+                        padding: '2px 4px',
+                        font: '12px monospace',
+                    }}
+                />
+                <button
+                    onClick={() => seedShapes(seedN)}
+                    style={{
+                        flex: 1,
+                        background: '#3a3a3a',
+                        color: '#fff',
+                        border: '1px solid #666',
+                        borderRadius: 4,
+                        padding: '2px 6px',
+                        cursor: 'pointer',
+                        font: '12px monospace',
+                    }}
+                    title="Seed N test shapes into a local draft and reload"
+                >
+                    seed + reload
+                </button>
+            </div>
+        </div>
+    )
+}
+
+export default PerfOverlay

--- a/src/components/elements/arrowLine.tsx
+++ b/src/components/elements/arrowLine.tsx
@@ -17,6 +17,7 @@ import {
     attachStrokeCounterScale,
 } from '../../utils/handleScale'
 import { useMediaQueryUtils } from '../../constants/exportHooks'
+import { scheduleRender } from '../../utils/renderScheduler'
 
 // Clickable band width (screen px) around the line, held constant at any zoom so
 // the line stays easy to select even at 10%.
@@ -87,6 +88,7 @@ function ArrowLine(props: ElementProps): ReactElement {
     }
 
     useEffect(() => {
+        let mountCancelled = false
         let hitAreaObserver: MutationObserver | null = null
         let detachHandleScale: (() => void) | null = null
         let detachHitScale: (() => void) | null = null
@@ -102,12 +104,8 @@ function ArrowLine(props: ElementProps): ReactElement {
             linewidth: props.linewidth,
             isMobile,
         })
-        const {
-            group,
-            pointCircle1Group,
-            pointCircle2Group,
-            line,
-        } = elementFactory.createElement()
+        const { group, pointCircle1Group, pointCircle2Group, line } =
+            elementFactory.createElement()
         group.elementData = { ...props.itemData, ...props }
         line.opacity = readOpacity(props)
         if (props.stroke) line.stroke = props.stroke
@@ -116,7 +114,7 @@ function ArrowLine(props: ElementProps): ReactElement {
         if (props.parentGroup) {
             const parentGroup = props.parentGroup
             parentGroup.add(group)
-            two.update()
+            scheduleRender(two)
         } else {
             groupObject = group
             stateRefForGroup.current = group
@@ -124,8 +122,6 @@ function ArrowLine(props: ElementProps): ReactElement {
                 pointCircle1Group,
                 pointCircle2Group,
             }
-
-            two.update()
 
             // Hold the endpoint circles at a constant on-screen size so they
             // stay grabbable when zoomed far out (else ~0.8px at 20%).
@@ -135,79 +131,97 @@ function ArrowLine(props: ElementProps): ReactElement {
                 two?.scene?.scale ?? 1
             )
 
-            const lineDomElem = document.getElementById(line.id)
-            if (lineDomElem) {
-                const HIT_INSET = 20
-                const hitElem = document.createElementNS(
-                    'http://www.w3.org/2000/svg',
-                    'line'
-                )
-                hitElem.setAttribute('stroke', 'transparent')
-                hitElem.setAttribute('pointer-events', 'stroke')
-                // Match the selection controller's body cursor (a drag zone).
-                hitElem.style.cursor = 'move'
+            // Every DOM read below needs the rendered SVG nodes, which only
+            // exist after a render. Batch that render with every other element
+            // mounting this frame — a synchronous two.update() per element made
+            // mounting a board O(N²). `mountCancelled` guards an unmount before
+            // the frame fires, so we never observe/bind a node already gone.
+            scheduleRender(two, () => {
+                if (mountCancelled) return
 
-                const syncHitLine = (): void => {
-                    const v0 = line.vertices[0]
-                    const v1 = line.vertices[1]
-                    const dx = v1.x - v0.x
-                    const dy = v1.y - v0.y
-                    const len = Math.sqrt(dx * dx + dy * dy)
-                    if (len < HIT_INSET * 2 + 5) return
-                    const r = HIT_INSET / len
-                    hitElem.setAttribute('x1', String(v0.x + dx * r))
-                    hitElem.setAttribute('y1', String(v0.y + dy * r))
-                    hitElem.setAttribute('x2', String(v1.x - dx * r))
-                    hitElem.setAttribute('y2', String(v1.y - dy * r))
+                const lineDomElem = document.getElementById(line.id)
+                if (lineDomElem) {
+                    const HIT_INSET = 20
+                    const hitElem = document.createElementNS(
+                        'http://www.w3.org/2000/svg',
+                        'line'
+                    )
+                    hitElem.setAttribute('stroke', 'transparent')
+                    hitElem.setAttribute('pointer-events', 'stroke')
+                    // Match the selection controller's body cursor (a drag zone).
+                    hitElem.style.cursor = 'move'
+
+                    const syncHitLine = (): void => {
+                        const v0 = line.vertices[0]
+                        const v1 = line.vertices[1]
+                        const dx = v1.x - v0.x
+                        const dy = v1.y - v0.y
+                        const len = Math.sqrt(dx * dx + dy * dy)
+                        if (len < HIT_INSET * 2 + 5) return
+                        const r = HIT_INSET / len
+                        hitElem.setAttribute('x1', String(v0.x + dx * r))
+                        hitElem.setAttribute('y1', String(v0.y + dy * r))
+                        hitElem.setAttribute('x2', String(v1.x - dx * r))
+                        hitElem.setAttribute('y2', String(v1.y - dy * r))
+                    }
+
+                    syncHitLine()
+                    lineDomElem.parentNode?.insertBefore(hitElem, lineDomElem)
+                    hitAreaObserver = new MutationObserver(syncHitLine)
+                    hitAreaObserver.observe(lineDomElem, {
+                        attributes: true,
+                        attributeFilter: ['d'],
+                    })
+                    // Keep the clickable band a constant screen width at any zoom.
+                    detachHitScale = attachStrokeCounterScale(
+                        (w) => hitElem.setAttribute('stroke-width', String(w)),
+                        HIT_BAND_PX,
+                        two,
+                        two?.scene?.scale ?? 1
+                    )
                 }
 
-                syncHitLine()
-                lineDomElem.parentNode?.insertBefore(hitElem, lineDomElem)
-                hitAreaObserver = new MutationObserver(syncHitLine)
-                hitAreaObserver.observe(lineDomElem, {
-                    attributes: true,
-                    attributeFilter: ['d'],
-                })
-                // Keep the clickable band a constant screen width at any zoom.
-                detachHitScale = attachStrokeCounterScale(
-                    (w) => hitElem.setAttribute('stroke-width', String(w)),
-                    HIT_BAND_PX,
-                    two,
-                    two?.scene?.scale ?? 1
-                )
-            }
+                // Show the `move` cursor over the line + endpoint circles, matching
+                // the selection controller's body cursor for other shapes. Inline so
+                // it beats the base `.dragger-picker { cursor: pointer }` rule, but
+                // still yields to the `!important` draw/pan-mode cursor overrides.
+                const lineEl = document.getElementById(line.id)
+                if (lineEl) lineEl.style.cursor = 'move'
+                const p1El = document.getElementById(pointCircle1Group.id)
+                if (p1El) {
+                    p1El.style.cursor = 'move'
+                    p1El.setAttribute('class', 'dragger-picker is-line-circle')
+                    p1El.setAttribute('data-parent-id', group.id)
+                    p1El.setAttribute('data-line-id', line.id)
+                    p1El.setAttribute('data-direction', 'left')
+                }
+                const p2El = document.getElementById(pointCircle2Group.id)
+                if (p2El) {
+                    p2El.style.cursor = 'move'
+                    p2El.setAttribute('class', 'dragger-picker is-line-circle')
+                    p2El.setAttribute('data-parent-id', group.id)
+                    p2El.setAttribute('data-line-id', line.id)
+                    p2El.setAttribute('data-direction', 'right')
+                }
+                const groupEl = document.getElementById(group.id)
+                if (groupEl) {
+                    groupEl.setAttribute('class', 'dragger-picker')
+                    groupEl.setAttribute('data-component-id', props.id)
+                    groupEl.setAttribute(
+                        'data-linewidth',
+                        String(props.linewidth ?? '')
+                    )
+                }
 
-            // Show the `move` cursor over the line + endpoint circles, matching
-            // the selection controller's body cursor for other shapes. Inline so
-            // it beats the base `.dragger-picker { cursor: pointer }` rule, but
-            // still yields to the `!important` draw/pan-mode cursor overrides.
-            const lineEl = document.getElementById(line.id)
-            if (lineEl) lineEl.style.cursor = 'move'
-            const p1El = document.getElementById(pointCircle1Group.id)
-            if (p1El) {
-                p1El.style.cursor = 'move'
-                p1El.setAttribute('class', 'dragger-picker is-line-circle')
-                p1El.setAttribute('data-parent-id', group.id)
-                p1El.setAttribute('data-line-id', line.id)
-                p1El.setAttribute('data-direction', 'left')
-            }
-            const p2El = document.getElementById(pointCircle2Group.id)
-            if (p2El) {
-                p2El.style.cursor = 'move'
-                p2El.setAttribute('class', 'dragger-picker is-line-circle')
-                p2El.setAttribute('data-parent-id', group.id)
-                p2El.setAttribute('data-line-id', line.id)
-                p2El.setAttribute('data-direction', 'right')
-            }
-            const groupEl = document.getElementById(group.id)
-            if (groupEl) {
-                groupEl.setAttribute('class', 'dragger-picker')
-                groupEl.setAttribute('data-component-id', props.id)
-                groupEl.setAttribute(
-                    'data-linewidth',
-                    String(props.linewidth ?? '')
+                const getGroupElementFromDOM = document.getElementById(
+                    `${group.id}`
                 )
-            }
+                getGroupElementFromDOM?.addEventListener(
+                    'focus',
+                    onFocusHandler
+                )
+                getGroupElementFromDOM?.addEventListener('blur', onBlurHandler)
+            })
 
             setInternalState((draft) => {
                 draft.element = {
@@ -228,15 +242,10 @@ function ArrowLine(props: ElementProps): ReactElement {
                 draft.text = { data: {} }
                 draft.icon = { data: {} }
             })
-
-            const getGroupElementFromDOM = document.getElementById(
-                `${group.id}`
-            )
-            getGroupElementFromDOM?.addEventListener('focus', onFocusHandler)
-            getGroupElementFromDOM?.addEventListener('blur', onBlurHandler)
         }
 
         return (): void => {
+            mountCancelled = true
             hitAreaObserver?.disconnect()
             detachHandleScale?.()
             detachHitScale?.()
@@ -252,7 +261,7 @@ function ArrowLine(props: ElementProps): ReactElement {
             groupInstance.translation.x = props.x
             groupInstance.translation.y = props.y
             lineInstance.opacity = readOpacity(props)
-            two.update()
+            scheduleRender(two)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.x, props.y, props.metadata])
@@ -263,7 +272,7 @@ function ArrowLine(props: ElementProps): ReactElement {
             if (props.stroke) lineInstance.stroke = props.stroke
             if (props.linewidth) lineInstance.linewidth = props.linewidth
             lineInstance.dashes = strokeTypeToDashes(props.strokeType)
-            two.update()
+            scheduleRender(two)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.stroke, props.linewidth, props.strokeType])

--- a/src/components/elements/circle.tsx
+++ b/src/components/elements/circle.tsx
@@ -5,6 +5,7 @@ import { useBoardContext } from '../../views/Board/boardContext'
 import CircleFactory from '../../factory/circle'
 import { strokeTypeToDashes } from '../../utils/misc'
 import { applyShapeText, readOpacity } from '../../utils/canvasUtils'
+import { scheduleRender } from '../../utils/renderScheduler'
 import { componentTypes } from '../../constants/misc'
 
 // Element components receive a fluid prop bag composed of the ComponentRecord
@@ -42,7 +43,7 @@ function Circle(props: ElementProps): ReactElement {
             circle.translation.x = props.properties.x
             circle.translation.y = props.properties.y
             parentGroup.add(circle)
-            two.update()
+            scheduleRender(two)
         } else {
             groupRef.current = group
             shapeRef.current = circle
@@ -62,17 +63,19 @@ function Circle(props: ElementProps): ReactElement {
             // actually repaint (see rectangle.tsx for the unshift rationale).
             group.opacity = opacityValue
 
-            two.update()
-
-            const groupEl = document.getElementById(group.id)
-            if (groupEl) {
-                groupEl.setAttribute('class', 'dragger-picker')
-                groupEl.setAttribute('data-component-id', props.id)
-                groupEl.setAttribute(
-                    'data-linewidth',
-                    String(props.linewidth ?? '')
-                )
-            }
+            // The SVG node only exists after a render. Batch the render
+            // with every other element mounting this frame, then tag it.
+            scheduleRender(two, () => {
+                const groupEl = document.getElementById(group.id)
+                if (groupEl) {
+                    groupEl.setAttribute('class', 'dragger-picker')
+                    groupEl.setAttribute('data-component-id', props.id)
+                    groupEl.setAttribute(
+                        'data-linewidth',
+                        String(props.linewidth ?? '')
+                    )
+                }
+            })
         }
 
         return (): void => {
@@ -91,7 +94,7 @@ function Circle(props: ElementProps): ReactElement {
         shapeInstance.width = props.width || shapeInstance.width
         shapeInstance.height = props.height || shapeInstance.height
         shapeInstance.fill = props.fill || shapeInstance.fill
-        two.update()
+        scheduleRender(two)
     }, [props.x, props.y, props.fill, props.width, props.height, two])
 
     // Re-wrap the embedded text whenever the box width or text metadata
@@ -107,13 +110,13 @@ function Circle(props: ElementProps): ReactElement {
             props.width || shapeInstance.width || 100,
             props.metadata || {}
         )
-        two.update()
+        scheduleRender(two)
     }, [props.width, props.metadata, two])
 
     useEffect(() => {
         if (shapeRef.current) {
             shapeRef.current.dashes = strokeTypeToDashes(props.strokeType)
-            two.update()
+            scheduleRender(two)
         }
     }, [props.strokeType, two])
 

--- a/src/components/elements/curvedLine.tsx
+++ b/src/components/elements/curvedLine.tsx
@@ -8,6 +8,7 @@ import {
     attachHandleCounterScale,
     attachStrokeCounterScale,
 } from '../../utils/handleScale'
+import { scheduleRender } from '../../utils/renderScheduler'
 
 // A multi-point curved line. Renders as an open, curved Two.Path (see the
 // factory). Unlike the geo route it does NOT counter-scale on zoom — a plain
@@ -61,6 +62,7 @@ function CurvedLine(props: ElementProps): ReactElement {
     }, [props.id])
 
     useEffect(() => {
+        let mountCancelled = false
         const prevX = props.x
         const prevY = props.y
 
@@ -77,7 +79,7 @@ function CurvedLine(props: ElementProps): ReactElement {
             path.translation.x = props.properties.x
             path.translation.y = props.properties.y
             parentGroup.add(path)
-            two.update()
+            scheduleRender(two)
             return (): void => {
                 two.remove(group)
             }
@@ -85,57 +87,6 @@ function CurvedLine(props: ElementProps): ReactElement {
 
         groupRef.current = group
         pathRef.current = path
-        two.update()
-
-        const groupEl = document.getElementById(group.id)
-        if (groupEl) {
-            groupEl.setAttribute('class', 'dragger-picker')
-            groupEl.setAttribute('data-component-id', props.id)
-            groupEl.setAttribute('data-linewidth', String(props.linewidth ?? ''))
-        }
-        // Show the `move` cursor over the line body, matching the selection
-        // controller's body cursor for other shapes (the curve is a drag zone).
-        // Inline beats the base `.dragger-picker` rule but yields to the
-        // `!important` draw/pan-mode overrides.
-        const pathEl = document.getElementById(path.id)
-        if (pathEl) pathEl.style.cursor = 'move'
-
-        // Fat transparent hit path so the (thin) curve is easy to click — its
-        // `d` mirrors the visible path (a MutationObserver tracks vertex drags
-        // for free), and its stroke width counter-scales so the clickable band
-        // stays a constant ~22px on screen at any zoom (else ~0.25px at 10%).
-        // A raw SVG node (not a Two child) so it never gets recolored/exported.
-        let hitObserver: MutationObserver | null = null
-        let detachHitScale: (() => void) | null = null
-        if (pathEl) {
-            const hitEl = document.createElementNS(
-                'http://www.w3.org/2000/svg',
-                'path'
-            )
-            hitEl.setAttribute('stroke', 'transparent')
-            hitEl.setAttribute('fill', 'none')
-            hitEl.setAttribute('pointer-events', 'stroke')
-            hitEl.setAttribute('stroke-linecap', 'round')
-            hitEl.setAttribute('stroke-linejoin', 'round')
-            hitEl.style.cursor = 'move'
-            const syncD = (): void => {
-                const d = pathEl.getAttribute('d')
-                if (d) hitEl.setAttribute('d', d)
-            }
-            syncD()
-            pathEl.parentNode?.insertBefore(hitEl, pathEl)
-            hitObserver = new MutationObserver(syncD)
-            hitObserver.observe(pathEl, {
-                attributes: true,
-                attributeFilter: ['d'],
-            })
-            detachHitScale = attachStrokeCounterScale(
-                (w) => hitEl.setAttribute('stroke-width', String(w)),
-                HIT_BAND_PX,
-                two,
-                zuiRef.current?.zui?.scale ?? two?.scene?.scale ?? 1
-            )
-        }
 
         // Build one draggable handle per vertex (children of the group, so they
         // move/scale with it). Hidden until the line is selected.
@@ -151,7 +102,6 @@ function CurvedLine(props: ElementProps): ReactElement {
             handles.push(handle)
         }
         handlesRef.current = handles
-        two.update()
 
         // Hold the vertex dots at a constant on-screen size so they stay
         // grabbable when zoomed far out (else ~1px at 20%).
@@ -163,70 +113,144 @@ function CurvedLine(props: ElementProps): ReactElement {
             initialScale
         )
 
-        // Per-vertex drag, wired directly on each handle's SVG node. stopPropagation
-        // keeps the canvas from also starting a body-drag / reselect.
+        let hitObserver: MutationObserver | null = null
+        let detachHitScale: (() => void) | null = null
         const cleanups: Array<() => void> = []
-        handles.forEach((handle, index) => {
-            const el = document.getElementById(handle.id)
-            if (!el) return
-            // `move` cursor on the vertex handles too, matching the body + the
-            // selection controller's drag-zone cursor.
-            el.style.cursor = 'move'
-            el.setAttribute('class', 'dragger-picker is-vertex-handle')
-            el.setAttribute('data-vertex-index', String(index))
-            // Hidden handles must not eat clicks (opacity-0 SVG still hit-tests).
-            el.style.pointerEvents = 'none'
 
-            const onMouseDown = (e: MouseEvent): void => {
-                e.preventDefault()
-                e.stopPropagation()
+        // Every DOM read below needs the rendered SVG nodes, which only exist
+        // after a render. Batch that render with every other element mounting
+        // this frame — a synchronous two.update() per element made mounting a
+        // board O(N²). `mountCancelled` guards an unmount before the frame
+        // fires, so we never observe/bind a node that is already gone.
+        scheduleRender(two, () => {
+            if (mountCancelled) return
 
-                const onMove = (me: MouseEvent): void => {
-                    const z = zuiRef.current
-                    const grp = groupRef.current
-                    const pth = pathRef.current
-                    if (!z?.zui || !grp || !pth) return
-                    const surface = z.zui.clientToSurface(me.clientX, me.clientY)
-                    const vertex = pth.vertices[index]
-                    vertex.x = surface.x - grp.translation.x
-                    vertex.y = surface.y - grp.translation.y
-                    handle.translation.x = vertex.x
-                    handle.translation.y = vertex.y
-                    // Curved, non-manual Path recomputes its control points from
-                    // the anchors on render — flag the vertices so it re-flows.
-                    pth._flagVertices = true
-                    two.update()
+            const groupEl = document.getElementById(group.id)
+            if (groupEl) {
+                groupEl.setAttribute('class', 'dragger-picker')
+                groupEl.setAttribute('data-component-id', props.id)
+                groupEl.setAttribute(
+                    'data-linewidth',
+                    String(props.linewidth ?? '')
+                )
+            }
+            // Show the `move` cursor over the line body, matching the selection
+            // controller's body cursor for other shapes (the curve is a drag zone).
+            // Inline beats the base `.dragger-picker` rule but yields to the
+            // `!important` draw/pan-mode overrides.
+            const pathEl = document.getElementById(path.id)
+            if (pathEl) pathEl.style.cursor = 'move'
+
+            // Fat transparent hit path so the (thin) curve is easy to click — its
+            // `d` mirrors the visible path (a MutationObserver tracks vertex drags
+            // for free), and its stroke width counter-scales so the clickable band
+            // stays a constant ~22px on screen at any zoom (else ~0.25px at 10%).
+            // A raw SVG node (not a Two child) so it never gets recolored/exported.
+            if (pathEl) {
+                const hitEl = document.createElementNS(
+                    'http://www.w3.org/2000/svg',
+                    'path'
+                )
+                hitEl.setAttribute('stroke', 'transparent')
+                hitEl.setAttribute('fill', 'none')
+                hitEl.setAttribute('pointer-events', 'stroke')
+                hitEl.setAttribute('stroke-linecap', 'round')
+                hitEl.setAttribute('stroke-linejoin', 'round')
+                hitEl.style.cursor = 'move'
+                const syncD = (): void => {
+                    const d = pathEl.getAttribute('d')
+                    if (d) hitEl.setAttribute('d', d)
                 }
-
-                const onUp = (): void => {
-                    window.removeEventListener('mousemove', onMove)
-                    window.removeEventListener('mouseup', onUp)
-                    const grp = groupRef.current
-                    const pth = pathRef.current
-                    if (!grp || !pth) return
-                    // Persist absolute vertex coords (same convention as route).
-                    const newVerts = pth.vertices.map((vx: ShapeLike) => ({
-                        x: Math.round(grp.translation.x + vx.x),
-                        y: Math.round(grp.translation.y + vx.y),
-                    }))
-                    grp.elementData = { ...grp.elementData, metadata: newVerts }
-                    // Records an UPDATE_BULK so the vertex edit is undoable. The
-                    // component snapshots props at mount (frozen props), so the
-                    // history hook can't revert us via a re-render — it fires a
-                    // `curvedLineVertsReverted` event instead, which the effect
-                    // below re-flows (path + handles) from the reverted metadata.
-                    persistRef.current?.(idRef.current, { metadata: newVerts })
-                }
-
-                window.addEventListener('mousemove', onMove)
-                window.addEventListener('mouseup', onUp)
+                syncD()
+                pathEl.parentNode?.insertBefore(hitEl, pathEl)
+                hitObserver = new MutationObserver(syncD)
+                hitObserver.observe(pathEl, {
+                    attributes: true,
+                    attributeFilter: ['d'],
+                })
+                detachHitScale = attachStrokeCounterScale(
+                    (w) => hitEl.setAttribute('stroke-width', String(w)),
+                    HIT_BAND_PX,
+                    two,
+                    zuiRef.current?.zui?.scale ?? two?.scene?.scale ?? 1
+                )
             }
 
-            el.addEventListener('mousedown', onMouseDown)
-            cleanups.push(() => el.removeEventListener('mousedown', onMouseDown))
+            // Per-vertex drag, wired directly on each handle's SVG node. stopPropagation
+            // keeps the canvas from also starting a body-drag / reselect.
+            handles.forEach((handle, index) => {
+                const el = document.getElementById(handle.id)
+                if (!el) return
+                // `move` cursor on the vertex handles too, matching the body + the
+                // selection controller's drag-zone cursor.
+                el.style.cursor = 'move'
+                el.setAttribute('class', 'dragger-picker is-vertex-handle')
+                el.setAttribute('data-vertex-index', String(index))
+                // Hidden handles must not eat clicks (opacity-0 SVG still hit-tests).
+                el.style.pointerEvents = 'none'
+
+                const onMouseDown = (e: MouseEvent): void => {
+                    e.preventDefault()
+                    e.stopPropagation()
+
+                    const onMove = (me: MouseEvent): void => {
+                        const z = zuiRef.current
+                        const grp = groupRef.current
+                        const pth = pathRef.current
+                        if (!z?.zui || !grp || !pth) return
+                        const surface = z.zui.clientToSurface(
+                            me.clientX,
+                            me.clientY
+                        )
+                        const vertex = pth.vertices[index]
+                        vertex.x = surface.x - grp.translation.x
+                        vertex.y = surface.y - grp.translation.y
+                        handle.translation.x = vertex.x
+                        handle.translation.y = vertex.y
+                        // Curved, non-manual Path recomputes its control points from
+                        // the anchors on render — flag the vertices so it re-flows.
+                        pth._flagVertices = true
+                        two.update()
+                    }
+
+                    const onUp = (): void => {
+                        window.removeEventListener('mousemove', onMove)
+                        window.removeEventListener('mouseup', onUp)
+                        const grp = groupRef.current
+                        const pth = pathRef.current
+                        if (!grp || !pth) return
+                        // Persist absolute vertex coords (same convention as route).
+                        const newVerts = pth.vertices.map((vx: ShapeLike) => ({
+                            x: Math.round(grp.translation.x + vx.x),
+                            y: Math.round(grp.translation.y + vx.y),
+                        }))
+                        grp.elementData = {
+                            ...grp.elementData,
+                            metadata: newVerts,
+                        }
+                        // Records an UPDATE_BULK so the vertex edit is undoable. The
+                        // component snapshots props at mount (frozen props), so the
+                        // history hook can't revert us via a re-render — it fires a
+                        // `curvedLineVertsReverted` event instead, which the effect
+                        // below re-flows (path + handles) from the reverted metadata.
+                        persistRef.current?.(idRef.current, {
+                            metadata: newVerts,
+                        })
+                    }
+
+                    window.addEventListener('mousemove', onMove)
+                    window.addEventListener('mouseup', onUp)
+                }
+
+                el.addEventListener('mousedown', onMouseDown)
+                cleanups.push(() =>
+                    el.removeEventListener('mousedown', onMouseDown)
+                )
+            })
         })
 
         return (): void => {
+            mountCancelled = true
             hitObserver?.disconnect()
             detachHitScale?.()
             detachHandleScale()
@@ -248,7 +272,7 @@ function CurvedLine(props: ElementProps): ReactElement {
             const el = document.getElementById(handle.id)
             if (el) el.style.pointerEvents = isSelected ? 'auto' : 'none'
         })
-        two.update()
+        scheduleRender(two)
     }, [selectedComponent, two])
 
     // Undo/redo of a vertex edit reverts our `metadata` in the store, but
@@ -299,7 +323,7 @@ function CurvedLine(props: ElementProps): ReactElement {
         if (props.stroke) path.stroke = props.stroke
         if (props.linewidth) path.linewidth = props.linewidth
         path.dashes = strokeTypeToDashes(props.strokeType)
-        two.update()
+        scheduleRender(two)
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.stroke, props.linewidth, props.strokeType])
 

--- a/src/components/elements/diamond.tsx
+++ b/src/components/elements/diamond.tsx
@@ -5,6 +5,7 @@ import { useBoardContext } from '../../views/Board/boardContext'
 import ElementFactory from '../../factory/diamond'
 import { strokeTypeToDashes } from '../../utils/misc'
 import { applyShapeText, readOpacity } from '../../utils/canvasUtils'
+import { scheduleRender } from '../../utils/renderScheduler'
 import { componentTypes } from '../../constants/misc'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -35,7 +36,7 @@ function Diamond(props: ElementProps): ReactElement {
             const parentGroup = props.parentGroup
             diamond.opacity = opacityValue
             parentGroup.add(diamond)
-            two.update()
+            scheduleRender(two)
         } else {
             groupRef.current = group
             shapeRef.current = diamond
@@ -55,17 +56,19 @@ function Diamond(props: ElementProps): ReactElement {
             // actually repaint (see rectangle.tsx for the unshift rationale).
             group.opacity = opacityValue
 
-            two.update()
-
-            const groupEl = document.getElementById(group.id)
-            if (groupEl) {
-                groupEl.setAttribute('class', 'dragger-picker')
-                groupEl.setAttribute('data-component-id', props.id)
-                groupEl.setAttribute(
-                    'data-linewidth',
-                    String(props.linewidth ?? '')
-                )
-            }
+            // The SVG node only exists after a render. Batch the render
+            // with every other element mounting this frame, then tag it.
+            scheduleRender(two, () => {
+                const groupEl = document.getElementById(group.id)
+                if (groupEl) {
+                    groupEl.setAttribute('class', 'dragger-picker')
+                    groupEl.setAttribute('data-component-id', props.id)
+                    groupEl.setAttribute(
+                        'data-linewidth',
+                        String(props.linewidth ?? '')
+                    )
+                }
+            })
         }
 
         return (): void => {
@@ -84,7 +87,7 @@ function Diamond(props: ElementProps): ReactElement {
         if (props.width) shapeInstance.width = props.width
         if (props.height) shapeInstance.height = props.height
         shapeInstance.fill = props.fill || shapeInstance.fill
-        two.update()
+        scheduleRender(two)
     }, [props.x, props.y, props.width, props.height, props.fill, two])
 
     // Re-wrap the embedded text whenever the box width or text metadata
@@ -100,13 +103,13 @@ function Diamond(props: ElementProps): ReactElement {
             props.width || shapeInstance.width || 120,
             props.metadata || {}
         )
-        two.update()
+        scheduleRender(two)
     }, [props.width, props.metadata, two])
 
     useEffect(() => {
         if (shapeRef.current) {
             shapeRef.current.dashes = strokeTypeToDashes(props.strokeType)
-            two.update()
+            scheduleRender(two)
         }
     }, [props.strokeType, two])
 

--- a/src/components/elements/divider.tsx
+++ b/src/components/elements/divider.tsx
@@ -7,6 +7,7 @@ import { strokeTypeToDashes } from '../../utils/misc'
 
 import ElementCreator from '../../factory/divider'
 import { readOpacity } from '../../utils/canvasUtils'
+import { scheduleRender } from '../../utils/renderScheduler'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ElementProps = any
@@ -91,32 +92,39 @@ function Divider(props: ElementProps): ReactElement {
         if (props.parentGroup) {
             const parentGroup = props.parentGroup
             parentGroup.add(group)
-            two.update()
+            scheduleRender(two)
         } else {
             groupObject = group
             stateRefForGroup.current = group
 
             selectorInstance = { pointCircle1, pointCircle2 }
 
-            two.update()
+            // SVG nodes exist only after a render. Batch this render with every
+            // other element mounting in this frame, then tag the nodes and wire
+            // up focus/blur — all of which need the nodes to be in the DOM.
+            scheduleRender(two, () => {
+                const lineEl = document.getElementById(line.id)
+                if (lineEl) lineEl.style.cursor = 'pointer'
+                const p1El = document.getElementById(pointCircle1.id)
+                if (p1El) {
+                    p1El.style.cursor = 'pointer'
+                    p1El.setAttribute('class', 'avoid-dragging')
+                }
+                const p2El = document.getElementById(pointCircle2.id)
+                if (p2El) {
+                    p2El.style.cursor = 'pointer'
+                    p2El.setAttribute('class', 'avoid-dragging')
+                }
+                const groupEl = document.getElementById(group.id)
+                if (groupEl) {
+                    groupEl.setAttribute('class', 'dragger-picker')
+                    groupEl.setAttribute('data-component-id', props.id)
+                }
 
-            const lineEl = document.getElementById(line.id)
-            if (lineEl) lineEl.style.cursor = 'pointer'
-            const p1El = document.getElementById(pointCircle1.id)
-            if (p1El) {
-                p1El.style.cursor = 'pointer'
-                p1El.setAttribute('class', 'avoid-dragging')
-            }
-            const p2El = document.getElementById(pointCircle2.id)
-            if (p2El) {
-                p2El.style.cursor = 'pointer'
-                p2El.setAttribute('class', 'avoid-dragging')
-            }
-            const groupEl = document.getElementById(group.id)
-            if (groupEl) {
-                groupEl.setAttribute('class', 'dragger-picker')
-                groupEl.setAttribute('data-component-id', props.id)
-            }
+                const el = document.getElementById(`${group.id}`)
+                el?.addEventListener('focus', onFocusHandler)
+                el?.addEventListener('blur', onBlurHandler)
+            })
 
             setInternalState((draft) => {
                 draft.element = {
@@ -131,10 +139,6 @@ function Divider(props: ElementProps): ReactElement {
                 draft.text = { data: {} }
                 draft.icon = { data: {} }
             })
-
-            const el = document.getElementById(`${group.id}`)
-            el?.addEventListener('focus', onFocusHandler)
-            el?.addEventListener('blur', onBlurHandler)
         }
 
         return (): void => {
@@ -148,7 +152,7 @@ function Divider(props: ElementProps): ReactElement {
             internalState.line.data.dashes = strokeTypeToDashes(
                 props.strokeType
             )
-            two.update()
+            scheduleRender(two)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.strokeType])
@@ -306,7 +310,7 @@ function Divider(props: ElementProps): ReactElement {
 
             groupInstance.translation.x = props.x
             groupInstance.translation.y = props.y
-            two.update()
+            scheduleRender(two)
 
             updateX1Y1VerticesLocal(
                 lineInstance,
@@ -322,7 +326,15 @@ function Divider(props: ElementProps): ReactElement {
             )
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [props.x, props.y, props.metadata, props.x1, props.x2, props.y1, props.y2])
+    }, [
+        props.x,
+        props.y,
+        props.metadata,
+        props.x1,
+        props.x2,
+        props.y1,
+        props.y2,
+    ])
 
     void toggleToolbar
 

--- a/src/components/elements/line.tsx
+++ b/src/components/elements/line.tsx
@@ -17,6 +17,7 @@ import {
     attachStrokeCounterScale,
 } from '../../utils/handleScale'
 import { useMediaQueryUtils } from '../../constants/exportHooks'
+import { scheduleRender } from '../../utils/renderScheduler'
 
 // Clickable band width (screen px) around the line, held constant at any zoom so
 // the line stays easy to select even at 10%.
@@ -92,6 +93,7 @@ function Line(props: ElementProps): ReactElement {
     }
 
     useEffect(() => {
+        let mountCancelled = false
         let hitAreaObserver: MutationObserver | null = null
         let detachHandleScale: (() => void) | null = null
         let detachHitScale: (() => void) | null = null
@@ -107,12 +109,8 @@ function Line(props: ElementProps): ReactElement {
             linewidth: props.linewidth,
             isMobile,
         })
-        const {
-            group,
-            pointCircle1Group,
-            pointCircle2Group,
-            line,
-        } = elementFactory.createElement()
+        const { group, pointCircle1Group, pointCircle2Group, line } =
+            elementFactory.createElement()
         group.elementData = { ...props.itemData, ...props }
         line.opacity = readOpacity(props)
         if (props.stroke) line.stroke = props.stroke
@@ -121,7 +119,7 @@ function Line(props: ElementProps): ReactElement {
         if (props.parentGroup) {
             const parentGroup = props.parentGroup
             parentGroup.add(group)
-            two.update()
+            scheduleRender(two)
         } else {
             groupObject = group
             stateRefForGroup.current = group
@@ -129,8 +127,6 @@ function Line(props: ElementProps): ReactElement {
                 pointCircle1Group,
                 pointCircle2Group,
             }
-
-            two.update()
 
             // Hold the endpoint circles at a constant on-screen size so they
             // stay grabbable when zoomed far out (else ~0.8px at 20%).
@@ -140,79 +136,97 @@ function Line(props: ElementProps): ReactElement {
                 two?.scene?.scale ?? 1
             )
 
-            const lineDomElem = document.getElementById(line.id)
-            if (lineDomElem) {
-                const HIT_INSET = 20
-                const hitElem = document.createElementNS(
-                    'http://www.w3.org/2000/svg',
-                    'line'
-                )
-                hitElem.setAttribute('stroke', 'transparent')
-                hitElem.setAttribute('pointer-events', 'stroke')
-                // Match the selection controller's body cursor (a drag zone).
-                hitElem.style.cursor = 'move'
+            // Every DOM read below needs the rendered SVG nodes, which only
+            // exist after a render. Batch that render with every other element
+            // mounting this frame — a synchronous two.update() per element made
+            // mounting a board O(N²). `mountCancelled` guards an unmount before
+            // the frame fires, so we never observe/bind a node already gone.
+            scheduleRender(two, () => {
+                if (mountCancelled) return
 
-                const syncHitLine = (): void => {
-                    const v0 = line.vertices[0]
-                    const v1 = line.vertices[1]
-                    const dx = v1.x - v0.x
-                    const dy = v1.y - v0.y
-                    const len = Math.sqrt(dx * dx + dy * dy)
-                    if (len < HIT_INSET * 2 + 5) return
-                    const r = HIT_INSET / len
-                    hitElem.setAttribute('x1', String(v0.x + dx * r))
-                    hitElem.setAttribute('y1', String(v0.y + dy * r))
-                    hitElem.setAttribute('x2', String(v1.x - dx * r))
-                    hitElem.setAttribute('y2', String(v1.y - dy * r))
+                const lineDomElem = document.getElementById(line.id)
+                if (lineDomElem) {
+                    const HIT_INSET = 20
+                    const hitElem = document.createElementNS(
+                        'http://www.w3.org/2000/svg',
+                        'line'
+                    )
+                    hitElem.setAttribute('stroke', 'transparent')
+                    hitElem.setAttribute('pointer-events', 'stroke')
+                    // Match the selection controller's body cursor (a drag zone).
+                    hitElem.style.cursor = 'move'
+
+                    const syncHitLine = (): void => {
+                        const v0 = line.vertices[0]
+                        const v1 = line.vertices[1]
+                        const dx = v1.x - v0.x
+                        const dy = v1.y - v0.y
+                        const len = Math.sqrt(dx * dx + dy * dy)
+                        if (len < HIT_INSET * 2 + 5) return
+                        const r = HIT_INSET / len
+                        hitElem.setAttribute('x1', String(v0.x + dx * r))
+                        hitElem.setAttribute('y1', String(v0.y + dy * r))
+                        hitElem.setAttribute('x2', String(v1.x - dx * r))
+                        hitElem.setAttribute('y2', String(v1.y - dy * r))
+                    }
+
+                    syncHitLine()
+                    lineDomElem.parentNode?.insertBefore(hitElem, lineDomElem)
+                    hitAreaObserver = new MutationObserver(syncHitLine)
+                    hitAreaObserver.observe(lineDomElem, {
+                        attributes: true,
+                        attributeFilter: ['d'],
+                    })
+                    // Keep the clickable band a constant screen width at any zoom.
+                    detachHitScale = attachStrokeCounterScale(
+                        (w) => hitElem.setAttribute('stroke-width', String(w)),
+                        HIT_BAND_PX,
+                        two,
+                        two?.scene?.scale ?? 1
+                    )
                 }
 
-                syncHitLine()
-                lineDomElem.parentNode?.insertBefore(hitElem, lineDomElem)
-                hitAreaObserver = new MutationObserver(syncHitLine)
-                hitAreaObserver.observe(lineDomElem, {
-                    attributes: true,
-                    attributeFilter: ['d'],
-                })
-                // Keep the clickable band a constant screen width at any zoom.
-                detachHitScale = attachStrokeCounterScale(
-                    (w) => hitElem.setAttribute('stroke-width', String(w)),
-                    HIT_BAND_PX,
-                    two,
-                    two?.scene?.scale ?? 1
-                )
-            }
+                // Show the `move` cursor over the line + endpoint circles, matching
+                // the selection controller's body cursor for other shapes. Inline so
+                // it beats the base `.dragger-picker { cursor: pointer }` rule, but
+                // still yields to the `!important` draw/pan-mode cursor overrides.
+                const lineEl = document.getElementById(line.id)
+                if (lineEl) lineEl.style.cursor = 'move'
+                const p1El = document.getElementById(pointCircle1Group.id)
+                if (p1El) {
+                    p1El.style.cursor = 'move'
+                    p1El.setAttribute('class', 'dragger-picker is-line-circle')
+                    p1El.setAttribute('data-parent-id', group.id)
+                    p1El.setAttribute('data-line-id', line.id)
+                    p1El.setAttribute('data-direction', 'left')
+                }
+                const p2El = document.getElementById(pointCircle2Group.id)
+                if (p2El) {
+                    p2El.style.cursor = 'move'
+                    p2El.setAttribute('class', 'dragger-picker is-line-circle')
+                    p2El.setAttribute('data-parent-id', group.id)
+                    p2El.setAttribute('data-line-id', line.id)
+                    p2El.setAttribute('data-direction', 'right')
+                }
+                const groupEl = document.getElementById(group.id)
+                if (groupEl) {
+                    groupEl.setAttribute('class', 'dragger-picker')
+                    groupEl.setAttribute('data-component-id', props.id)
+                    groupEl.setAttribute(
+                        'data-linewidth',
+                        String(props.linewidth ?? '')
+                    )
+                }
 
-            // Show the `move` cursor over the line + endpoint circles, matching
-            // the selection controller's body cursor for other shapes. Inline so
-            // it beats the base `.dragger-picker { cursor: pointer }` rule, but
-            // still yields to the `!important` draw/pan-mode cursor overrides.
-            const lineEl = document.getElementById(line.id)
-            if (lineEl) lineEl.style.cursor = 'move'
-            const p1El = document.getElementById(pointCircle1Group.id)
-            if (p1El) {
-                p1El.style.cursor = 'move'
-                p1El.setAttribute('class', 'dragger-picker is-line-circle')
-                p1El.setAttribute('data-parent-id', group.id)
-                p1El.setAttribute('data-line-id', line.id)
-                p1El.setAttribute('data-direction', 'left')
-            }
-            const p2El = document.getElementById(pointCircle2Group.id)
-            if (p2El) {
-                p2El.style.cursor = 'move'
-                p2El.setAttribute('class', 'dragger-picker is-line-circle')
-                p2El.setAttribute('data-parent-id', group.id)
-                p2El.setAttribute('data-line-id', line.id)
-                p2El.setAttribute('data-direction', 'right')
-            }
-            const groupEl = document.getElementById(group.id)
-            if (groupEl) {
-                groupEl.setAttribute('class', 'dragger-picker')
-                groupEl.setAttribute('data-component-id', props.id)
-                groupEl.setAttribute(
-                    'data-linewidth',
-                    String(props.linewidth ?? '')
+                const getGroupElementFromDOM = document.getElementById(
+                    `${group.id}`
                 )
-            }
+                getGroupElementFromDOM?.addEventListener(
+                    'focus',
+                    onFocusHandler
+                )
+                getGroupElementFromDOM?.addEventListener('blur', onBlurHandler)
+            })
 
             setInternalState((draft) => {
                 draft.element = {
@@ -233,15 +247,10 @@ function Line(props: ElementProps): ReactElement {
                 draft.text = { data: {} }
                 draft.icon = { data: {} }
             })
-
-            const getGroupElementFromDOM = document.getElementById(
-                `${group.id}`
-            )
-            getGroupElementFromDOM?.addEventListener('focus', onFocusHandler)
-            getGroupElementFromDOM?.addEventListener('blur', onBlurHandler)
         }
 
         return (): void => {
+            mountCancelled = true
             hitAreaObserver?.disconnect()
             detachHandleScale?.()
             detachHitScale?.()
@@ -257,7 +266,7 @@ function Line(props: ElementProps): ReactElement {
             groupInstance.translation.x = props.x
             groupInstance.translation.y = props.y
             lineInstance.opacity = readOpacity(props)
-            two.update()
+            scheduleRender(two)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.x, props.y, props.metadata])
@@ -268,7 +277,7 @@ function Line(props: ElementProps): ReactElement {
             if (props.stroke) lineInstance.stroke = props.stroke
             if (props.linewidth) lineInstance.linewidth = props.linewidth
             lineInstance.dashes = strokeTypeToDashes(props.strokeType)
-            two.update()
+            scheduleRender(two)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.stroke, props.linewidth, props.strokeType])

--- a/src/components/elements/newText.tsx
+++ b/src/components/elements/newText.tsx
@@ -8,6 +8,7 @@ import { syncTextHitRect, readOpacity } from '../../utils/canvasUtils'
 import { lineHeightFor } from '../../utils/textLayout'
 import { htmlToBulletText } from '../../utils/htmlToBulletText'
 import { DEFAULT_TEXT_FONT_FAMILY } from '../../constants/misc'
+import { scheduleRender } from '../../utils/renderScheduler'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ElementProps = any
@@ -43,6 +44,7 @@ function NewText(props: ElementProps): ReactElement {
     const two = props.twoJSInstance
 
     useEffect(() => {
+        let mountCancelled = false
         const prevX = props.x
         const prevY = props.y
 
@@ -92,7 +94,7 @@ function NewText(props: ElementProps): ReactElement {
             // Keep the transparent hit area covering the whole block so clicks
             // in the gaps between lines still select the text (see canvasUtils).
             syncTextHitRect(two, group)
-            two.update()
+            scheduleRender(two)
         }
         syncMultilineRef.current = syncMultilineLayout
 
@@ -136,13 +138,29 @@ function NewText(props: ElementProps): ReactElement {
 
         // Render any persisted multiline content as the stacked block.
         syncMultilineLayout()
-        two.update()
 
-        const groupEl = document.getElementById(group.id)
-        if (groupEl) {
-            groupEl.setAttribute('class', 'dragger-picker')
-            groupEl.setAttribute('data-component-id', props.id)
-        }
+        // Everything below that touches the DOM (node tagging, the dblclick
+        // listeners) needs the rendered SVG nodes, which only exist after a
+        // render. Batch that render with every other element mounting this
+        // frame — a synchronous two.update() per element made mounting a board
+        // O(N²). `mountCancelled` guards an unmount before the frame fires, so
+        // we never bind listeners to a node that is already gone.
+        scheduleRender(two, () => {
+            if (mountCancelled) return
+
+            const groupEl = document.getElementById(group.id)
+            if (groupEl) {
+                groupEl.setAttribute('class', 'dragger-picker')
+                groupEl.setAttribute('data-component-id', props.id)
+            }
+
+            twoText._renderer?.elem?.addEventListener('dblclick', () => {
+                showTextInput()
+            })
+            groupEl?.addEventListener('dblclick', () => {
+                showTextInput()
+            })
+        })
 
         setInternalState((draft) => {
             draft.group = { id: group.id, data: group }
@@ -151,8 +169,6 @@ function NewText(props: ElementProps): ReactElement {
             draft.text = { id: twoText.id, data: twoText }
             draft.icon = { data: {} }
         })
-
-        const getGroupElementFromDOM = document.getElementById(`${group.id}`)
 
         const showTextInput = (): void => {
             // A dblclick bubbles from the text node to the group, firing BOTH
@@ -227,7 +243,10 @@ function NewText(props: ElementProps): ReactElement {
             // Calibrate the constant part (canvas page offset + glyph bearing)
             // from the real start position so there's no jump entering edit.
             const calibX =
-                startRect.left - 8 - two.scene.translation.x - surfaceLeft * scale0
+                startRect.left -
+                8 -
+                two.scene.translation.x -
+                surfaceLeft * scale0
             const calibY =
                 startRect.top +
                 startRect.height / 2 -
@@ -444,13 +463,6 @@ function NewText(props: ElementProps): ReactElement {
             })
         }
 
-        twoText._renderer.elem.addEventListener('dblclick', () => {
-            showTextInput()
-        })
-        getGroupElementFromDOM?.addEventListener('dblclick', () => {
-            showTextInput()
-        })
-
         const handleTriggerTextInput = (e: Event): void => {
             const detail = (e as CustomEvent<{ elementId: string }>).detail
             if (detail?.elementId === props.id) {
@@ -460,6 +472,7 @@ function NewText(props: ElementProps): ReactElement {
         window.addEventListener('triggerTextInput', handleTriggerTextInput)
 
         return (): void => {
+            mountCancelled = true
             window.removeEventListener(
                 'triggerTextInput',
                 handleTriggerTextInput
@@ -472,7 +485,7 @@ function NewText(props: ElementProps): ReactElement {
         if (internalState?.group?.data) {
             internalState.group.data.translation.x = props.x
             internalState.group.data.translation.y = props.y
-            two.update()
+            scheduleRender(two)
         }
 
         if (internalState?.twoText?.data) {
@@ -501,7 +514,7 @@ function NewText(props: ElementProps): ReactElement {
             // group-apply, plus external content updates).
             syncMultilineRef.current?.()
 
-            two.update()
+            scheduleRender(two)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.x, props.y, props.textColor, props.metadata])

--- a/src/components/elements/pencil.tsx
+++ b/src/components/elements/pencil.tsx
@@ -6,6 +6,7 @@ import { strokeTypeToDashes } from '../../utils/misc'
 import getEditComponents from '../utils/editWrapper'
 import PencilFactory from '../../factory/pencil'
 import { readOpacity } from '../../utils/canvasUtils'
+import { scheduleRender } from '../../utils/renderScheduler'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ElementProps = any
@@ -39,7 +40,7 @@ function Pencil(props: ElementProps): ReactElement {
             shapeRef.translation.y = props.properties.y
             shapeRef.opacity = pencilOpacity
             parentGroup.add(shapeRef)
-            two.update()
+            scheduleRender(two)
         } else {
             group.opacity = pencilOpacity
             getEditComponents(two, group, 4)
@@ -47,17 +48,19 @@ function Pencil(props: ElementProps): ReactElement {
             if (path) {
                 group.children.unshift(path)
             }
-            two.update()
-
-            const groupEl = document.getElementById(group.id)
-            if (groupEl) {
-                groupEl.setAttribute('class', 'avoid-dragging')
-                groupEl.setAttribute('data-component-id', props.id)
-                groupEl.setAttribute(
-                    'data-linewidth',
-                    String(props.linewidth ?? '')
-                )
-            }
+            // SVG node exists only after a render. Batch this render with
+            // every other element mounting in this frame, then tag the node.
+            scheduleRender(two, () => {
+                const groupEl = document.getElementById(group.id)
+                if (groupEl) {
+                    groupEl.setAttribute('class', 'avoid-dragging')
+                    groupEl.setAttribute('data-component-id', props.id)
+                    groupEl.setAttribute(
+                        'data-linewidth',
+                        String(props.linewidth ?? '')
+                    )
+                }
+            })
 
             setInternalState((draft) => {
                 draft.element = {
@@ -88,7 +91,7 @@ function Pencil(props: ElementProps): ReactElement {
             const groupInstance = internalState.group.data
             groupInstance.translation.x = props.x
             groupInstance.translation.y = props.y
-            two.update()
+            scheduleRender(two)
         }
         if (internalState?.shape?.data) {
             const shapeInstance = internalState.shape.data
@@ -99,7 +102,7 @@ function Pencil(props: ElementProps): ReactElement {
                 ? props.height
                 : shapeInstance.height
             shapeInstance.fill = props.fill ? props.fill : shapeInstance.fill
-            two.update()
+            scheduleRender(two)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.x, props.y, props.fill, props.width, props.height])
@@ -111,7 +114,7 @@ function Pencil(props: ElementProps): ReactElement {
             internalState.group.data.children.forEach((child: any) => {
                 child.dashes = dashes
             })
-            two.update()
+            scheduleRender(two)
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [props.strokeType])

--- a/src/components/elements/rectangle.tsx
+++ b/src/components/elements/rectangle.tsx
@@ -5,6 +5,7 @@ import { useBoardContext } from '../../views/Board/boardContext'
 import ElementFactory from '../../factory/rectangle'
 import { strokeTypeToDashes } from '../../utils/misc'
 import { applyShapeText, readOpacity } from '../../utils/canvasUtils'
+import { scheduleRender } from '../../utils/renderScheduler'
 import { componentTypes } from '../../constants/misc'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -35,7 +36,7 @@ function Rectangle(props: ElementProps): ReactElement {
             const parentGroup = props.parentGroup
             rectangle.opacity = opacityValue
             parentGroup.add(rectangle)
-            two.update()
+            scheduleRender(two)
         } else {
             groupRef.current = group
             shapeRef.current = rectangle
@@ -57,17 +58,19 @@ function Rectangle(props: ElementProps): ReactElement {
             // which leaves leaf-level opacity flags unprocessed on render).
             group.opacity = opacityValue
 
-            two.update()
-
-            const groupEl = document.getElementById(group.id)
-            if (groupEl) {
-                groupEl.setAttribute('class', 'dragger-picker')
-                groupEl.setAttribute('data-component-id', props.id)
-                groupEl.setAttribute(
-                    'data-linewidth',
-                    String(props.linewidth ?? '')
-                )
-            }
+            // The SVG node only exists after a render. Batch the render with
+            // every other element mounting this frame, then tag the node.
+            scheduleRender(two, () => {
+                const groupEl = document.getElementById(group.id)
+                if (groupEl) {
+                    groupEl.setAttribute('class', 'dragger-picker')
+                    groupEl.setAttribute('data-component-id', props.id)
+                    groupEl.setAttribute(
+                        'data-linewidth',
+                        String(props.linewidth ?? '')
+                    )
+                }
+            })
         }
 
         return (): void => {
@@ -86,7 +89,7 @@ function Rectangle(props: ElementProps): ReactElement {
         shapeInstance.width = props.width || shapeInstance.width
         shapeInstance.height = props.height || shapeInstance.height
         shapeInstance.fill = props.fill || shapeInstance.fill
-        two.update()
+        scheduleRender(two)
     }, [props.x, props.y, props.width, props.height, props.fill, two])
 
     // Re-wrap the embedded text whenever the box width or text metadata
@@ -102,13 +105,13 @@ function Rectangle(props: ElementProps): ReactElement {
             props.width || shapeInstance.width || 120,
             props.metadata || {}
         )
-        two.update()
+        scheduleRender(two)
     }, [props.width, props.metadata, two])
 
     useEffect(() => {
         if (shapeRef.current) {
             shapeRef.current.dashes = strokeTypeToDashes(props.strokeType)
-            two.update()
+            scheduleRender(two)
         }
     }, [props.strokeType, two])
 

--- a/src/components/modals/BoardSizeLimitModal.tsx
+++ b/src/components/modals/BoardSizeLimitModal.tsx
@@ -1,0 +1,113 @@
+import type { ReactElement } from 'react'
+import Modal from '../common/modal'
+import Button from '../common/button'
+import {
+    MAX_DRAFT_BYTES,
+    MAX_DRAFT_UTF8_BYTES,
+} from '../../utils/boardSizeGuard'
+
+// Load-side ceiling is a UTF-16 storage-footprint estimate; the write-side
+// budget is a real UTF-8 size (what the live readout shows).
+const loadBudgetMb = Math.round(MAX_DRAFT_BYTES / (1024 * 1024))
+const writeBudgetMb = Math.round(MAX_DRAFT_UTF8_BYTES / (1024 * 1024))
+
+interface BoardFullModalProps {
+    open: boolean
+    onClose: () => void
+    onExport: () => void
+}
+
+/**
+ * Write-side notice: a paste/draw was rolled back because it would have pushed
+ * the board past the size budget. Non-destructive — the revert already ran, so
+ * this just explains it and offers an export as the way to keep growing.
+ */
+export function BoardFullModal({
+    open,
+    onClose,
+    onExport,
+}: BoardFullModalProps): ReactElement {
+    return (
+        <Modal open={open} onClose={onClose} locked={false}>
+            <div className="p-4" style={{ minWidth: '400px' }}>
+                <h2 className="text-lg font-semibold mb-2">Board is full</h2>
+                <p className="text-sm text-neutrals-n700 mb-4">
+                    This board reached the ~{writeBudgetMb} MB size limit, so your
+                    last change was undone to keep it stable and loadable.
+                    Export the board to a file if you want to keep building on
+                    it elsewhere.
+                </p>
+                <div className="flex gap-2">
+                    <Button
+                        intent="primary"
+                        size="medium"
+                        label="Export as JSON"
+                        onClick={onExport}
+                    />
+                    <Button
+                        intent="secondary"
+                        size="medium"
+                        label="Got it"
+                        onClick={onClose}
+                    />
+                </div>
+            </div>
+        </Modal>
+    )
+}
+
+interface BoardTooLargeModalProps {
+    open: boolean
+    onDownloadBackup: () => void
+    onStartFresh: () => void
+    onOpenAnyway: () => void
+}
+
+/**
+ * Load-side rescue: the persisted draft is too large to render without
+ * freezing. Shown INSTEAD of loading it. "Download backup" reads the raw draft
+ * straight from localStorage (no rendering), so it works even though the board
+ * can't be opened normally. `locked` so it can't be dismissed into a frozen
+ * canvas — the user must pick a recovery path.
+ */
+export function BoardTooLargeModal({
+    open,
+    onDownloadBackup,
+    onStartFresh,
+    onOpenAnyway,
+}: BoardTooLargeModalProps): ReactElement {
+    return (
+        <Modal open={open} onClose={() => {}} locked>
+            <div className="p-4" style={{ minWidth: '400px' }}>
+                <h2 className="text-lg font-semibold mb-2">
+                    This board is too large to open
+                </h2>
+                <p className="text-sm text-neutrals-n700 mb-4">
+                    It exceeds the ~{loadBudgetMb} MB limit and opening it may
+                    freeze the page. Download a backup of your work first, then
+                    start with a fresh canvas.
+                </p>
+                <div className="flex gap-2">
+                    <Button
+                        intent="primary"
+                        size="medium"
+                        label="Download backup"
+                        onClick={onDownloadBackup}
+                    />
+                    <Button
+                        intent="secondary"
+                        size="medium"
+                        label="Start fresh"
+                        onClick={onStartFresh}
+                    />
+                </div>
+                <button
+                    className="mt-3 text-xs text-neutrals-n700 underline hover:text-ink"
+                    onClick={onOpenAnyway}
+                >
+                    Open anyway (may freeze)
+                </button>
+            </div>
+        </Modal>
+    )
+}

--- a/src/components/modals/ImportBoardModal.tsx
+++ b/src/components/modals/ImportBoardModal.tsx
@@ -1,0 +1,91 @@
+import type { ReactElement } from 'react'
+import Modal from '../common/modal'
+import Button from '../common/button'
+
+interface ImportBoardModalProps {
+    open: boolean
+    onClose: () => void
+    /** When set, the modal shows an error state instead of the chooser. */
+    error?: string | null
+    total?: number
+    skipped?: number
+    onOpenAsNew?: () => void
+    onMerge?: () => void
+}
+
+/**
+ * Post-file-pick chooser for importing a board. On success it asks how to
+ * apply the file — replace the canvas or merge into it. On a hard failure
+ * (bad JSON / not a board / nothing valid) it surfaces the error with a single
+ * dismiss.
+ */
+export default function ImportBoardModal({
+    open,
+    onClose,
+    error,
+    total = 0,
+    skipped = 0,
+    onOpenAsNew,
+    onMerge,
+}: ImportBoardModalProps): ReactElement {
+    const valid = total - skipped
+
+    return (
+        <Modal open={open} onClose={onClose} locked={false}>
+            <div className="p-4" style={{ minWidth: '400px' }}>
+                {error ? (
+                    <>
+                        <h2 className="text-lg font-semibold mb-2">
+                            Couldn’t import board
+                        </h2>
+                        <p className="text-sm text-neutrals-n700 mb-4">
+                            {error}
+                        </p>
+                        <div className="flex gap-2">
+                            <Button
+                                intent="primary"
+                                size="medium"
+                                label="Close"
+                                onClick={onClose}
+                            />
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <h2 className="text-lg font-semibold mb-2">
+                            Import board
+                        </h2>
+                        <p className="text-sm text-neutrals-n700 mb-1">
+                            Found {valid} element{valid === 1 ? '' : 's'} in
+                            this file.
+                        </p>
+                        {skipped > 0 && (
+                            <p className="text-xs text-neutrals-n700 mb-3">
+                                {skipped} unreadable item
+                                {skipped === 1 ? '' : 's'} will be skipped.
+                            </p>
+                        )}
+                        <p className="text-sm text-neutrals-n700 mb-4">
+                            Open it as a new canvas (replaces your current
+                            board) or merge it into what you have now?
+                        </p>
+                        <div className="flex gap-2">
+                            <Button
+                                intent="primary"
+                                size="medium"
+                                label="Open as new canvas"
+                                onClick={onOpenAsNew}
+                            />
+                            <Button
+                                intent="secondary"
+                                size="medium"
+                                label="Merge into current"
+                                onClick={onMerge}
+                            />
+                        </div>
+                    </>
+                )}
+            </div>
+        </Modal>
+    )
+}

--- a/src/components/sidebar/menuDrawer.tsx
+++ b/src/components/sidebar/menuDrawer.tsx
@@ -4,12 +4,14 @@ import { Link } from 'react-router-dom'
 import routes from '../../routes'
 import { useBoardContext } from '../../views/Board/boardContext'
 import { downloadViewportAsImage } from '../../utils/exportViewport'
+import { exportBoardAsJson } from '../../utils/exportBoard'
 import Modal from '../common/modal'
 import Button from '../common/button'
 import SettingsModal from './settingsModal'
 import ShortcutsModal from './shortcutsModal'
 import SettingsIcon from '../../assets/settings.svg?react'
 import HelpIcon from '../../assets/help.svg?react'
+import ChevronRightIcon from '../../assets/chevron-right.svg?react'
 
 const HamburgerIcon = (): ReactElement => (
     <svg
@@ -100,7 +102,9 @@ const MenuDrawer = (): ReactElement => {
     const [showSettings, setShowSettings] = useState(false)
     const [showShortcuts, setShowShortcuts] = useState(false)
     const [isExporting, setIsExporting] = useState(false)
-    const { clearBoard } = useBoardContext()
+    const [showExportSubmenu, setShowExportSubmenu] = useState(false)
+    const { clearBoard, stateRefForComponentStore, twoJSInstance } =
+        useBoardContext()
 
     useEffect(() => {
         const handleClick = (e: MouseEvent): void => {
@@ -112,6 +116,12 @@ const MenuDrawer = (): ReactElement => {
             document.removeEventListener('mousedown', handleClick, false)
         }
     }, [])
+
+    // Collapse the export flyout whenever the menu itself closes, so it never
+    // lingers open on the next menu open (covers outside-click + toggle paths).
+    useEffect(() => {
+        if (!showMenu) setShowExportSubmenu(false)
+    }, [showMenu])
 
     const handleClearClick = (): void => {
         setShowMenu(false)
@@ -138,6 +148,22 @@ const MenuDrawer = (): ReactElement => {
         } finally {
             setIsExporting(false)
         }
+    }
+
+    const handleExportJson = (): void => {
+        const scene = twoJSInstance?.scene
+        const viewport = scene
+            ? {
+                  // scene.scale is uniform (number) in this app; guard the
+                  // Two.js Vector union rather than cast.
+                  scale: typeof scene.scale === 'number' ? scene.scale : 1,
+                  tx: scene.translation.x,
+                  ty: scene.translation.y,
+              }
+            : { scale: 1, tx: 0, ty: 0 }
+        exportBoardAsJson(stateRefForComponentStore.current, viewport)
+        setShowExportSubmenu(false)
+        setShowMenu(false)
     }
 
     const handleConfirmClear = (): void => {
@@ -335,6 +361,57 @@ const MenuDrawer = (): ReactElement => {
                         </button>
 
                         <div className="h-px bg-border-panel mx-2 mt-1 mb-1" />
+
+                        <div className="relative">
+                            <button
+                                className="flex items-center justify-between gap-2.5 px-3 py-2 mx-1 text-sm text-ink-mid
+                                    hover:bg-accent/50 rounded cursor-pointer
+                                    transition-colors ease-in-out duration-150"
+                                style={{ width: 'calc(100% - 8px)' }}
+                                onClick={(): void =>
+                                    setShowExportSubmenu((prev) => !prev)
+                                }
+                            >
+                                <span className="flex items-center gap-2.5">
+                                    <DownloadIcon />
+                                    <span>Export board</span>
+                                </span>
+                                <ChevronRightIcon
+                                    className="w-3.5 h-3.5"
+                                    stroke="currentColor"
+                                    color="currentColor"
+                                    aria-hidden="true"
+                                />
+                            </button>
+
+                            {showExportSubmenu && (
+                                <div
+                                    className="absolute top-0 bg-card-bg border border-border-panel
+                                        rounded-lg shadow-lg py-1 w-max min-w-[152px] z-[101]"
+                                    style={{ left: '100%' }}
+                                >
+                                    <button
+                                        className="flex items-center gap-2.5 px-3 py-2 mx-1 text-sm text-ink-mid
+                                            hover:bg-accent/50 rounded cursor-pointer
+                                            transition-colors ease-in-out duration-150"
+                                        style={{ width: 'calc(100% - 8px)' }}
+                                        onClick={handleExportJson}
+                                    >
+                                        <span>Export as JSON</span>
+                                    </button>
+                                    <button
+                                        className="flex items-center gap-2.5 px-3 py-2 mx-1 text-sm text-ink-mid
+                                            rounded transition-colors ease-in-out duration-150
+                                            disabled:opacity-50 disabled:cursor-default"
+                                        style={{ width: 'calc(100% - 8px)' }}
+                                        title="Coming soon"
+                                        disabled
+                                    >
+                                        <span>Export as SVG</span>
+                                    </button>
+                                </div>
+                            )}
+                        </div>
 
                         <button
                             className="flex items-center gap-2.5 px-3 py-2 mx-1 text-sm text-ink-mid

--- a/src/components/sidebar/menuDrawer.tsx
+++ b/src/components/sidebar/menuDrawer.tsx
@@ -95,6 +95,31 @@ const DownloadIcon = (): ReactElement => (
     </svg>
 )
 
+const UploadIcon = (): ReactElement => (
+    <svg
+        width="14"
+        height="14"
+        viewBox="0 0 14 14"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M7 8.5v-7M4 4.5L7 1.5l3 3"
+            stroke="#8C7E6A"
+            strokeWidth="1.1"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+        <path
+            d="M2 9.5v1.5a1 1 0 001 1h8a1 1 0 001-1V9.5"
+            stroke="#8C7E6A"
+            strokeWidth="1.1"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        />
+    </svg>
+)
+
 const MenuDrawer = (): ReactElement => {
     const refNode = useRef<HTMLDivElement | null>(null)
     const [showMenu, setShowMenu] = useState(false)
@@ -103,8 +128,13 @@ const MenuDrawer = (): ReactElement => {
     const [showShortcuts, setShowShortcuts] = useState(false)
     const [isExporting, setIsExporting] = useState(false)
     const [showExportSubmenu, setShowExportSubmenu] = useState(false)
-    const { clearBoard, stateRefForComponentStore, twoJSInstance } =
-        useBoardContext()
+    const [showImportSubmenu, setShowImportSubmenu] = useState(false)
+    const {
+        clearBoard,
+        stateRefForComponentStore,
+        twoJSInstance,
+        beginBoardImport,
+    } = useBoardContext()
 
     useEffect(() => {
         const handleClick = (e: MouseEvent): void => {
@@ -117,10 +147,13 @@ const MenuDrawer = (): ReactElement => {
         }
     }, [])
 
-    // Collapse the export flyout whenever the menu itself closes, so it never
-    // lingers open on the next menu open (covers outside-click + toggle paths).
+    // Collapse the export/import flyouts whenever the menu itself closes, so
+    // neither lingers open on the next menu open (covers outside-click + toggle).
     useEffect(() => {
-        if (!showMenu) setShowExportSubmenu(false)
+        if (!showMenu) {
+            setShowExportSubmenu(false)
+            setShowImportSubmenu(false)
+        }
     }, [showMenu])
 
     const handleClearClick = (): void => {
@@ -164,6 +197,13 @@ const MenuDrawer = (): ReactElement => {
         exportBoardAsJson(stateRefForComponentStore.current, viewport)
         setShowExportSubmenu(false)
         setShowMenu(false)
+    }
+
+    const handleImportJson = (): void => {
+        setShowImportSubmenu(false)
+        setShowMenu(false)
+        // board.tsx owns the file-pick → parse → chooser flow.
+        beginBoardImport()
     }
 
     const handleConfirmClear = (): void => {
@@ -368,9 +408,10 @@ const MenuDrawer = (): ReactElement => {
                                     hover:bg-accent/50 rounded cursor-pointer
                                     transition-colors ease-in-out duration-150"
                                 style={{ width: 'calc(100% - 8px)' }}
-                                onClick={(): void =>
+                                onClick={(): void => {
+                                    setShowImportSubmenu(false)
                                     setShowExportSubmenu((prev) => !prev)
-                                }
+                                }}
                             >
                                 <span className="flex items-center gap-2.5">
                                     <DownloadIcon />
@@ -408,6 +449,58 @@ const MenuDrawer = (): ReactElement => {
                                         disabled
                                     >
                                         <span>Export as SVG</span>
+                                    </button>
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="relative">
+                            <button
+                                className="flex items-center justify-between gap-2.5 px-3 py-2 mx-1 text-sm text-ink-mid
+                                    hover:bg-accent/50 rounded cursor-pointer
+                                    transition-colors ease-in-out duration-150"
+                                style={{ width: 'calc(100% - 8px)' }}
+                                onClick={(): void => {
+                                    setShowExportSubmenu(false)
+                                    setShowImportSubmenu((prev) => !prev)
+                                }}
+                            >
+                                <span className="flex items-center gap-2.5">
+                                    <UploadIcon />
+                                    <span>Import board</span>
+                                </span>
+                                <ChevronRightIcon
+                                    className="w-3.5 h-3.5"
+                                    stroke="currentColor"
+                                    color="currentColor"
+                                    aria-hidden="true"
+                                />
+                            </button>
+
+                            {showImportSubmenu && (
+                                <div
+                                    className="absolute top-0 bg-card-bg border border-border-panel
+                                        rounded-lg shadow-lg py-1 w-max min-w-[152px] z-[101]"
+                                    style={{ left: '100%' }}
+                                >
+                                    <button
+                                        className="flex items-center gap-2.5 px-3 py-2 mx-1 text-sm text-ink-mid
+                                            hover:bg-accent/50 rounded cursor-pointer
+                                            transition-colors ease-in-out duration-150"
+                                        style={{ width: 'calc(100% - 8px)' }}
+                                        onClick={handleImportJson}
+                                    >
+                                        <span>Import JSON</span>
+                                    </button>
+                                    <button
+                                        className="flex items-center gap-2.5 px-3 py-2 mx-1 text-sm text-ink-mid
+                                            rounded transition-colors ease-in-out duration-150
+                                            disabled:opacity-50 disabled:cursor-default"
+                                        style={{ width: 'calc(100% - 8px)' }}
+                                        title="Coming soon"
+                                        disabled
+                                    >
+                                        <span>Import SVG</span>
                                     </button>
                                 </div>
                             )}

--- a/src/components/utils/elementRenderWrappers.tsx
+++ b/src/components/utils/elementRenderWrappers.tsx
@@ -28,11 +28,10 @@ export const ElementRenderWrapper = (
             useState<ComponentRecord | null>(null)
 
         useEffect(() => {
-            const allComponents = Object.values(componentStore)
-            if (allComponents.length > 0) {
-                const match = allComponents.find((item) => data.id === item.id)
-                if (match) setComponentData(match)
-            }
+            // Keyed lookup, not a scan: this runs once per element, so an
+            // Object.values(...).find() here made mounting a board O(n²).
+            const match = componentStore[data.id]
+            if (match) setComponentData(match)
         }, [])
 
         if (componentData === null) {

--- a/src/components/utils/objectSelector.ts
+++ b/src/components/utils/objectSelector.ts
@@ -1,5 +1,6 @@
 import Two from 'two.js'
 import { markSelectionChrome } from '../../utils/svgExportShared'
+import { scheduleRender } from '../../utils/renderScheduler'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TwoLike = any
@@ -102,10 +103,15 @@ export default class Selector {
 
         this.areaGroup = areaGroup
         this.group.add(areaGroup)
-        this.two.update()
-        // Tag the overlay so SVG/PNG exports can strip it — it lives inside the
-        // group's <g>, so a clone of the group would otherwise carry it.
-        markSelectionChrome(areaGroup)
+        // Batched, NOT a direct two.update(): this runs once per element that
+        // has edit chrome (every pencil), so a synchronous full-scene render
+        // here is O(N²) across a board load. markSelectionChrome reads
+        // `_renderer.elem`, so it must wait for the render — hence afterRender.
+        scheduleRender(this.two, () => {
+            // Tag the overlay so SVG/PNG exports can strip it — it lives inside
+            // the group's <g>, so a clone of the group would otherwise carry it.
+            markSelectionChrome(areaGroup)
+        })
 
         const clearSelector = (): void => {
             this.areaGroup.opacity = 0
@@ -141,24 +147,50 @@ export default class Selector {
         }
     }
 
-    update(
-        x1: number,
-        x2: number,
-        y1: number,
-        y2: number,
-        scale = 1
-    ): void {
+    update(x1: number, x2: number, y1: number, y2: number, scale = 1): void {
         this.vertices = { x1, x2, y1, y2 }
 
         this.area.vertices = [
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            new (Two as any).Anchor(x1, y1, null, null, null, null, (Two as any).Commands.line),
+            new (Two as any).Anchor(
+                x1,
+                y1,
+                null,
+                null,
+                null,
+                null,
+                (Two as any).Commands.line
+            ),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            new (Two as any).Anchor(x2, y1, null, null, null, null, (Two as any).Commands.line),
+            new (Two as any).Anchor(
+                x2,
+                y1,
+                null,
+                null,
+                null,
+                null,
+                (Two as any).Commands.line
+            ),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            new (Two as any).Anchor(x2, y2, null, null, null, null, (Two as any).Commands.line),
+            new (Two as any).Anchor(
+                x2,
+                y2,
+                null,
+                null,
+                null,
+                null,
+                (Two as any).Commands.line
+            ),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            new (Two as any).Anchor(x1, y2, null, null, null, null, (Two as any).Commands.line),
+            new (Two as any).Anchor(
+                x1,
+                y2,
+                null,
+                null,
+                null,
+                null,
+                (Two as any).Commands.line
+            ),
         ]
 
         if (this.showCircles) {

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -6,7 +6,7 @@ export const GROUP_COMPONENT = 'groupobject'
 // Fonts <link> in index.html. Every canvas-text fallback
 // (`family || DEFAULT_TEXT_FONT_FAMILY`) references this so the default lives in
 // exactly one place — including the welcome sketch (`SKETCH_FONT`).
-export const DEFAULT_TEXT_FONT_FAMILY = 'Caveat'
+export const DEFAULT_TEXT_FONT_FAMILY = 'Caveat Brush'
 
 export const RUBBER_MODE_KEY = 'rubberMode'
 export const VIEWPORT_KEY_PREFIX = 'craftbase_viewport_'

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -215,6 +215,12 @@ export const CONNECTORS_ENABLED_KEY = 'craftbase_connectors_enabled'
 // `src/utils/featureFlags.ts`). Defaults to disabled.
 export const DOT_GRID_ENABLED_KEY = 'craftbase_dot_grid_enabled'
 
+// Feature-flag preference: viewport culling. Hides scene elements whose
+// screen-space bounds fall outside the viewport so the SVG renderer skips
+// painting them — the lever against the pan/zoom paint cost on dense boards.
+// Read live (see `src/utils/featureFlags.ts`). Defaults to disabled.
+export const VIEWPORT_CULLING_ENABLED_KEY = 'craftbase_viewport_culling_enabled'
+
 // Canvas rendering constants
 export const HOVER_THRESHOLD = 15
 export const HOVER_COLOR = 'rgba(196, 144, 26, 0.7)'

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -215,6 +215,13 @@ export const CONNECTORS_ENABLED_KEY = 'craftbase_connectors_enabled'
 // `src/utils/featureFlags.ts`). Defaults to disabled.
 export const DOT_GRID_ENABLED_KEY = 'craftbase_dot_grid_enabled'
 
+// Perf-testing flag: the O(N) per-frame scene scans that ride along with
+// dragging — `reanchorArrowsForShape` (legacy move path), `shapeHasBoundArrows`
+// (CSS fast-path eligibility) and the hover-detect endpoint scan. Disable to
+// isolate their cost from the Two.js render/paint cost during stress tests.
+// Read live (see `src/utils/featureFlags.ts`). Defaults to enabled.
+export const DRAG_SCANS_ENABLED_KEY = 'craftbase_drag_scans_enabled'
+
 // Feature-flag preference: viewport culling. Hides scene elements whose
 // screen-space bounds fall outside the viewport so the SVG renderer skips
 // painting them — the lever against the pan/zoom paint cost on dense boards.

--- a/src/factory/newText.ts
+++ b/src/factory/newText.ts
@@ -1,5 +1,6 @@
 import Main from './main'
 import { DEFAULT_TEXT_FONT_FAMILY } from '../constants/misc'
+import { scheduleRender } from '../utils/renderScheduler'
 
 export interface NewTextMetadata {
     content?: string
@@ -39,7 +40,9 @@ export default class NewTextFactory extends Main<NewTextProperties> {
         group.translation.x = parseInt(String(prevX))
         group.translation.y = parseInt(String(prevY))
 
-        two.update()
+        // Batched, NOT a direct two.update(): this fires once per text element,
+        // so a synchronous full-scene render here is O(N²) across a board load.
+        scheduleRender(two)
 
         return { group, twoText }
     }

--- a/src/hooks/useLocalDraftPersistence.ts
+++ b/src/hooks/useLocalDraftPersistence.ts
@@ -13,6 +13,13 @@ import {
     buildWelcomeSketch,
     isWelcomeComponent,
 } from '../utils/welcomeSketch'
+import {
+    isRawDraftOverBudget,
+    readRawDraft,
+    downloadRawDraftBackup,
+    measureStoredDraftUtf8Bytes,
+    MAX_DRAFT_UTF8_BYTES,
+} from '../utils/boardSizeGuard'
 
 export interface LocalDraftPersistenceOptions {
     isPersisted: boolean
@@ -22,6 +29,12 @@ export interface LocalDraftPersistenceOptions {
     backgroundBoardIdRef: MutableRefObject<string | null>
     setBackgroundBoardId: Dispatch<SetStateAction<string | null>>
     onStorageLimitRef?: MutableRefObject<(() => void) | null>
+    /**
+     * Fired right after a draft write whose UTF-8 size exceeds
+     * `MAX_DRAFT_UTF8_BYTES` — the write-side guard. The host reverts the last
+     * action and surfaces the "board is full" modal.
+     */
+    onDraftOverBudgetRef?: MutableRefObject<(() => void) | null>
     /** Opt-in onboarding seed; see BoardProps.welcomeSketch. */
     welcomeSketch?: boolean
     /**
@@ -39,6 +52,13 @@ export interface LocalDraftPersistenceApi {
     setStorageLimitBoardUrl: Dispatch<SetStateAction<string | null>>
     handleStartNewCanvas: () => void
     handleContinueOnSavedBoard: () => void
+    // Load-side rescue for a persisted draft too large to render safely.
+    showBoardTooLargeModal: boolean
+    handleDownloadBoardBackup: () => void
+    handleStartFreshFromTooLarge: () => void
+    handleOpenBoardAnyway: () => void
+    /** Live UTF-8 byte size of the persisted draft, refreshed on every save. */
+    draftSizeBytes: number
 }
 
 interface PersistedDraft {
@@ -55,13 +75,20 @@ export function useLocalDraftPersistence({
     backgroundBoardIdRef,
     setBackgroundBoardId,
     onStorageLimitRef,
+    onDraftOverBudgetRef,
     welcomeSketch,
     isMobile,
 }: LocalDraftPersistenceOptions): LocalDraftPersistenceApi {
     const [showStorageLimitModal, setShowStorageLimitModal] = useState(false)
+    const [draftSizeBytes, setDraftSizeBytes] = useState(0)
     const [storageLimitBoardUrl, setStorageLimitBoardUrl] = useState<
         string | null
     >(null)
+    const [showBoardTooLargeModal, setShowBoardTooLargeModal] = useState(false)
+    // Raw (unparsed) draft text deliberately NOT loaded because it's over
+    // budget. Kept as a string — parsing it is itself heavy enough to stutter
+    // the page — so it's only parsed if the user explicitly hits "Open anyway".
+    const deferredRawDraftRef = useRef<string | null>(null)
     const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     // Restore draft and background board ID from localStorage on mount (local mode only)
@@ -78,21 +105,35 @@ export function useLocalDraftPersistence({
         try {
             const draft = localStorage.getItem(DRAFT_STORAGE_KEY)
             if (draft) {
-                const parsed = JSON.parse(draft) as PersistedDraft
-                const age = Date.now() - (parsed.timestamp ?? 0)
-                if (age < DRAFT_EXPIRY_MS && parsed.components) {
-                    const safeComponents = Object.fromEntries(
-                        Object.entries(parsed.components).filter(
-                            ([, v]) => v?.componentType !== GROUP_COMPONENT
-                        )
-                    ) as ComponentStore
-                    if (Object.keys(safeComponents).length > 0) {
-                        setComponentStore(safeComponents)
-                        restoredDraft = true
-                    }
+                // Load-side guard FIRST, on the raw string — before any parse.
+                // Parsing + rebuilding a multi-MB object graph is itself heavy
+                // enough to stutter the page, so an over-budget draft must
+                // never be parsed on load. Stash the raw text and surface the
+                // rescue modal instead; only "Open anyway" parses it.
+                // `restoredDraft` stays true so we don't seed the welcome
+                // sketch over it.
+                if (isRawDraftOverBudget(draft)) {
+                    deferredRawDraftRef.current = draft
+                    setShowBoardTooLargeModal(true)
+                    restoredDraft = true
                 } else {
-                    localStorage.removeItem(DRAFT_STORAGE_KEY)
-                    localStorage.removeItem(BACKGROUND_BOARD_STORAGE_KEY)
+                    const parsed = JSON.parse(draft) as PersistedDraft
+                    const age = Date.now() - (parsed.timestamp ?? 0)
+                    if (age < DRAFT_EXPIRY_MS && parsed.components) {
+                        const safeComponents = Object.fromEntries(
+                            Object.entries(parsed.components).filter(
+                                ([, v]) =>
+                                    v?.componentType !== GROUP_COMPONENT
+                            )
+                        ) as ComponentStore
+                        if (Object.keys(safeComponents).length > 0) {
+                            setComponentStore(safeComponents)
+                            restoredDraft = true
+                        }
+                    } else {
+                        localStorage.removeItem(DRAFT_STORAGE_KEY)
+                        localStorage.removeItem(BACKGROUND_BOARD_STORAGE_KEY)
+                    }
                 }
             }
         } catch {
@@ -145,6 +186,16 @@ export function useLocalDraftPersistence({
                         timestamp: Date.now(),
                     })
                 )
+
+                // Write-side guard: measure the REAL UTF-8 size of what we just
+                // persisted (TextEncoder on the draft key), keep the live
+                // readout current, and revert the last action if it's over the
+                // budget.
+                const bytes = measureStoredDraftUtf8Bytes()
+                setDraftSizeBytes(bytes)
+                if (bytes > MAX_DRAFT_UTF8_BYTES) {
+                    onDraftOverBudgetRef?.current?.()
+                }
             } catch (e) {
                 if (
                     e instanceof DOMException &&
@@ -196,6 +247,47 @@ export function useLocalDraftPersistence({
         }
     }
 
+    // Rescue: download the raw over-budget draft straight from localStorage
+    // (no rendering, so it can't freeze) so the user keeps their work.
+    const handleDownloadBoardBackup = (): void => {
+        const raw = readRawDraft()
+        if (raw) downloadRawDraftBackup(raw)
+    }
+
+    const handleStartFreshFromTooLarge = (): void => {
+        localStorage.removeItem(DRAFT_STORAGE_KEY)
+        deferredRawDraftRef.current = null
+        setShowBoardTooLargeModal(false)
+        window.location.href = '/'
+    }
+
+    // Explicit override: parse the deferred (over-budget) draft now and render
+    // it anyway — this is the heavy work the load path deliberately skipped, so
+    // it may freeze; the user opted in. The write-side guard leaves the result
+    // alone because the undo stack is empty.
+    const handleOpenBoardAnyway = (): void => {
+        const raw = deferredRawDraftRef.current
+        if (raw) {
+            try {
+                const parsed = JSON.parse(raw) as PersistedDraft
+                if (parsed.components) {
+                    const safeComponents = Object.fromEntries(
+                        Object.entries(parsed.components).filter(
+                            ([, v]) => v?.componentType !== GROUP_COMPONENT
+                        )
+                    ) as ComponentStore
+                    if (Object.keys(safeComponents).length > 0) {
+                        setComponentStore(safeComponents)
+                    }
+                }
+            } catch {
+                // Corrupt draft — nothing to open; fall through to close.
+            }
+            deferredRawDraftRef.current = null
+        }
+        setShowBoardTooLargeModal(false)
+    }
+
     return {
         showStorageLimitModal,
         setShowStorageLimitModal,
@@ -203,5 +295,10 @@ export function useLocalDraftPersistence({
         setStorageLimitBoardUrl,
         handleStartNewCanvas,
         handleContinueOnSavedBoard,
+        showBoardTooLargeModal,
+        handleDownloadBoardBackup,
+        handleStartFreshFromTooLarge,
+        handleOpenBoardAnyway,
+        draftSizeBytes,
     }
 }

--- a/src/newCanvas.tsx
+++ b/src/newCanvas.tsx
@@ -77,6 +77,7 @@ import {
     subscribeConnectorsEnabled,
     getDotGridEnabled,
     subscribeDotGridEnabled,
+    getDragScansEnabled,
     getViewportCullingEnabled,
 } from './utils/featureFlags'
 import {
@@ -453,7 +454,8 @@ function addZUI(
     let drawPreviewActive = false
     let drawScreenOriginX = 0
     let drawScreenOriginY = 0
-    // CSS-transform move-drag: while dragging a (non-rotated, non-group) element
+    // CSS-transform move-drag: while dragging a non-rotated element (including
+    // the group overlay, whose member copies + selector chrome share its node)
     // we translate its own SVG layer via a CSS transform + will-change instead of
     // mutating its Two.js position and calling a full-scene two.update() every
     // frame. The scene SVG is never touched, so the drag is a GPU composite —
@@ -474,6 +476,9 @@ function addZUI(
     let cssMoveStartClientY = 0
     let cssMoveLastDxWorld = 0
     let cssMoveLastDyWorld = 0
+    // Set once per drag when the shape is ineligible for the CSS fast-path (e.g.
+    // it has bound connectors) so the whole drag stays on the legacy live path.
+    let cssMoveRejected = false
 
     // Clear the live CSS transforms and drop the drag state. Called on commit
     // (mouseup) and defensively when a new gesture starts.
@@ -490,6 +495,7 @@ function addZUI(
         cssMoveEl = null
         cssMoveNode = null
         cssMoveChrome = null
+        cssMoveRejected = false
     }
     let drawShapeType: string | null = null
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1525,6 +1531,16 @@ function addZUI(
             }
             return
         }
+        // Perf-testing lever: skip the O(N) endpoint scan (arrow-endpoint hover
+        // indicator won't appear while off).
+        if (!getDragScansEnabled()) {
+            if (lastHoveredCircleGroup) {
+                hoverCircle.opacity = 0
+                scheduleRender(two)
+                lastHoveredCircleGroup = null
+            }
+            return
+        }
 
         const worldPos = toSurface(e)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1860,6 +1876,9 @@ function addZUI(
         // off, existing bindings lie dormant (the arrow stays put) rather than
         // being stripped — flip the flag back on to resume gluing.
         if (!getConnectorsEnabled()) return
+        // Perf-testing lever: skip the O(N) scene scan entirely (bound arrows
+        // won't follow their shape while off).
+        if (!getDragScansEnabled()) return
         const shapeId = group?.elementData?.id
         if (!shapeId) return
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1924,6 +1943,26 @@ function addZUI(
                     )
                 }
             }
+        })
+    }
+
+    // Does any connector currently dock onto this shape? Used to opt a shape out
+    // of the CSS-transform move fast-path: a bound arrow must reshape every frame
+    // to stay glued, which needs the shape's real position (not just a CSS
+    // transform), so such shapes fall back to the legacy live-render drag. O(N)
+    // scan, but run once at drag start — never per frame.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function shapeHasBoundArrows(group: any): boolean {
+        // Perf-testing lever: skip the O(N) scan; every shape then reads as
+        // unbound and stays eligible for the CSS move fast-path.
+        if (!getDragScansEnabled()) return false
+        const shapeId = group?.elementData?.id
+        if (!shapeId) return false
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return two.scene.children.some((child: any) => {
+            const ed = child?.elementData
+            if (ed?.componentType !== 'arrowLine') return false
+            return ed.tailShapeId === shapeId || ed.headShapeId === shapeId
         })
     }
 
@@ -2186,6 +2225,9 @@ function addZUI(
         // Defensive: a prior move-drag whose mouseup was missed (released off
         // canvas) would leave a stale CSS transform — clear it before a new one.
         if (cssMoveActive) clearCssMove()
+        // Reset the fast-path decision for the new gesture (a rejected drag never
+        // runs clearCssMove, so its flag would otherwise leak into the next one).
+        cssMoveRejected = false
         if (drawOrigin) {
             drawOrigin = null
             drawCurrentCoords = null
@@ -3087,14 +3129,34 @@ function addZUI(
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             const node = (shape as any)._renderer
                                 ?.elem as SVGGraphicsElement | undefined
-                            // CSS-transform move: eligible for non-rotated,
-                            // non-group elements. Rotated shapes and groups keep
-                            // the legacy position-mutate + full-render path.
-                            const eligible =
-                                !!node &&
-                                !shape.rotation &&
-                                shape.elementData?.componentType !==
-                                    GROUP_COMPONENT
+                            // CSS-transform move: eligible for non-rotated
+                            // elements, including the group overlay — its member
+                            // copies and selector chrome live inside its own SVG
+                            // node, so one transform moves them all; the mouseup
+                            // commit below writes the real translation before
+                            // groupobject's window-mouseup commitGroupMove reads
+                            // it (domElement listeners fire first in the bubble).
+                            // Rotated shapes keep the legacy path.
+                            const cheapEligible = !!node && !shape.rotation
+                            // Decide CSS-vs-legacy ONCE per drag. A shape with
+                            // bound connectors must reshape its arrows every
+                            // frame (needs its real position), so it takes the
+                            // legacy live-render path. The bound-arrow scan is
+                            // O(N) but runs only on this first-frame decision,
+                            // and only when connectors are on.
+                            if (
+                                cheapEligible &&
+                                !cssMoveActive &&
+                                !cssMoveRejected
+                            ) {
+                                if (
+                                    getConnectorsEnabled() &&
+                                    shapeHasBoundArrows(shape)
+                                ) {
+                                    cssMoveRejected = true
+                                }
+                            }
+                            const eligible = cheapEligible && !cssMoveRejected
                             if (eligible) {
                                 if (!cssMoveActive) {
                                     cssMoveActive = true

--- a/src/newCanvas.tsx
+++ b/src/newCanvas.tsx
@@ -85,6 +85,12 @@ import {
     CULLED_FLAG,
 } from './utils/viewportCulling'
 import {
+    createDrawPreview,
+    updateDrawPreview,
+    removeDrawPreview,
+    type DrawPreviewKind,
+} from './utils/drawPreviewOverlay'
+import {
     velocityToLinewidth,
     smoothLinewidth,
     simplifyWithLinewidth,
@@ -112,7 +118,6 @@ import {
 } from './utils/themeColorFlip'
 import { isSelectPanMode, isPanMode } from './utils/drawModeUtils'
 import { scheduleRender } from './utils/renderScheduler'
-import { createDiamondPath } from './factory/diamond'
 import { useCanvasClipboard } from './hooks/useCanvasClipboard'
 import type { HistoryEntry } from './hooks/useComponentHistory'
 import { exportSelectionAsSvg } from './utils/exportSelectionAsSvg'
@@ -442,8 +447,50 @@ function addZUI(
     let drawOrigin: any = null
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let drawCurrentCoords: any = null
+    // The shape-creation preview is a DOM overlay (see drawPreviewOverlay), not
+    // a Two.js scene child — so growing it never repaints the scene SVG. These
+    // hold the drag's start corner in *client* (screen) coords for the overlay.
+    let drawPreviewActive = false
+    let drawScreenOriginX = 0
+    let drawScreenOriginY = 0
+    // CSS-transform move-drag: while dragging a (non-rotated, non-group) element
+    // we translate its own SVG layer via a CSS transform + will-change instead of
+    // mutating its Two.js position and calling a full-scene two.update() every
+    // frame. The scene SVG is never touched, so the drag is a GPU composite —
+    // 60fps regardless of zoom or element count. The real position is written
+    // once on mouseup, so all the existing move/persist/history logic still runs.
+    let cssMoveActive = false
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let previewShape: any = null
+    let cssMoveEl: any = null
+    let cssMoveNode: SVGGraphicsElement | null = null
+    let cssMoveChrome: {
+        node: SVGGraphicsElement
+        baseX: number
+        baseY: number
+    } | null = null
+    let cssMoveBaseX = 0
+    let cssMoveBaseY = 0
+    let cssMoveStartClientX = 0
+    let cssMoveStartClientY = 0
+    let cssMoveLastDxWorld = 0
+    let cssMoveLastDyWorld = 0
+
+    // Clear the live CSS transforms and drop the drag state. Called on commit
+    // (mouseup) and defensively when a new gesture starts.
+    const clearCssMove = (): void => {
+        if (cssMoveNode) {
+            cssMoveNode.style.transform = ''
+            cssMoveNode.style.willChange = ''
+        }
+        if (cssMoveChrome) {
+            cssMoveChrome.node.style.transform = ''
+            cssMoveChrome.node.style.willChange = ''
+        }
+        cssMoveActive = false
+        cssMoveEl = null
+        cssMoveNode = null
+        cssMoveChrome = null
+    }
     let drawShapeType: string | null = null
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let drawShapeProps: any = null
@@ -2132,11 +2179,13 @@ function addZUI(
 
         // Clean up orphaned draw state from an interrupted drag
         // (e.g. user moved cursor outside canvas and released mouse there)
-        if (previewShape) {
-            two.remove(previewShape)
-            two.update()
-            previewShape = null
+        if (drawPreviewActive) {
+            removeDrawPreview()
+            drawPreviewActive = false
         }
+        // Defensive: a prior move-drag whose mouseup was missed (released off
+        // canvas) would leave a stale CSS transform — clear it before a new one.
+        if (cssMoveActive) clearCssMove()
         if (drawOrigin) {
             drawOrigin = null
             drawCurrentCoords = null
@@ -2323,36 +2372,28 @@ function addZUI(
                 localStorage.removeItem(PENDING_SHAPE_TYPE_KEY)
                 localStorage.removeItem(PENDING_SHAPE_PROPS_KEY)
 
-                if (drawShapeType === 'circle') {
-                    previewShape = two.makeEllipse(
-                        surfaceCoords.x,
-                        surfaceCoords.y,
-                        0,
-                        0
+                // Preview lives on a DOM overlay, positioned in client coords —
+                // it never enters the scene, so the drag never repaints the SVG.
+                if (
+                    drawShapeType === 'circle' ||
+                    drawShapeType === 'rectangle' ||
+                    drawShapeType === 'diamond'
+                ) {
+                    drawScreenOriginX = e.clientX
+                    drawScreenOriginY = e.clientY
+                    drawPreviewActive = true
+                    createDrawPreview(drawShapeType as DrawPreviewKind, {
+                        fill: drawShapeProps?.fill || '#fff',
+                        stroke: drawShapeProps?.stroke || SHAPE_DEFAULT_STROKE,
+                        linewidth: drawShapeProps?.linewidth || 1,
+                        opacity: DEFAULT_PREVIEW_OPACITY,
+                    })
+                    updateDrawPreview(
+                        e.clientX,
+                        e.clientY,
+                        e.clientX,
+                        e.clientY
                     )
-                } else if (drawShapeType === 'rectangle') {
-                    previewShape = two.makeRoundedRectangle(
-                        surfaceCoords.x,
-                        surfaceCoords.y,
-                        0,
-                        0,
-                        3
-                    )
-                } else if (drawShapeType === 'diamond') {
-                    previewShape = createDiamondPath(two, 0, 0, 6)
-                    previewShape.translation.set(
-                        surfaceCoords.x,
-                        surfaceCoords.y
-                    )
-                }
-
-                if (previewShape) {
-                    previewShape.fill = drawShapeProps?.fill || '#fff'
-                    previewShape.stroke =
-                        drawShapeProps?.stroke || SHAPE_DEFAULT_STROKE
-                    previewShape.linewidth = drawShapeProps?.linewidth || 1
-                    previewShape.opacity = DEFAULT_PREVIEW_OPACITY
-                    two.update()
                 }
 
                 domElement.addEventListener('mousemove', mousemove, false)
@@ -2675,6 +2716,9 @@ function addZUI(
     }
 
     function mousemove(e: MouseEvent) {
+        // Set when this frame moved a selected element via CSS transform (no
+        // scene render) — used to skip the full-scene two.update() at the end.
+        let didCssMove = false
         // Pan-mode (desktop): translate the surface by the per-frame mouse
         // delta. Mirrors the single-finger touch pan in touchmove.
         if (isMousePanning) {
@@ -2786,17 +2830,15 @@ function addZUI(
                     y: surfaceCoordsMove.y,
                 }
 
-                const drawWidth = Math.abs(surfaceCoordsMove.x - drawOrigin.x)
-                const drawHeight = Math.abs(surfaceCoordsMove.y - drawOrigin.y)
-                const centerX = (surfaceCoordsMove.x + drawOrigin.x) / 2
-                const centerY = (surfaceCoordsMove.y + drawOrigin.y) / 2
-
-                if (previewShape) {
-                    previewShape.translation.x = centerX
-                    previewShape.translation.y = centerY
-                    previewShape.width = drawWidth
-                    previewShape.height = drawHeight
-                    two.update()
+                // Grow the DOM overlay from client coords — O(1), no two.update(),
+                // so the scene SVG is never touched during the drag.
+                if (drawPreviewActive) {
+                    updateDrawPreview(
+                        drawScreenOriginX,
+                        drawScreenOriginY,
+                        e.clientX,
+                        e.clientY
+                    )
                 }
                 break
             }
@@ -3042,11 +3084,58 @@ function addZUI(
                         }
                         // code block condition to handle normal component's dragging
                         else {
-                            shape.position.x += dx / zui.scale
-                            shape.position.y += dy / zui.scale
-                            // Drag any connector tails/heads pinned to this
-                            // shape's ports along with it.
-                            reanchorArrowsForShape(shape)
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            const node = (shape as any)._renderer
+                                ?.elem as SVGGraphicsElement | undefined
+                            // CSS-transform move: eligible for non-rotated,
+                            // non-group elements. Rotated shapes and groups keep
+                            // the legacy position-mutate + full-render path.
+                            const eligible =
+                                !!node &&
+                                !shape.rotation &&
+                                shape.elementData?.componentType !==
+                                    GROUP_COMPONENT
+                            if (eligible) {
+                                if (!cssMoveActive) {
+                                    cssMoveActive = true
+                                    cssMoveEl = shape
+                                    cssMoveNode = node!
+                                    cssMoveBaseX = shape.position.x
+                                    cssMoveBaseY = shape.position.y
+                                    cssMoveLastDxWorld = 0
+                                    cssMoveLastDyWorld = 0
+                                    node!.style.willChange = 'transform'
+                                    // Move the selection box in lockstep so it
+                                    // stays glued to the element during the drag.
+                                    cssMoveChrome =
+                                        selectionController.getChromeDragHandle(
+                                            shape
+                                        )
+                                    if (cssMoveChrome) {
+                                        cssMoveChrome.node.style.willChange =
+                                            'transform'
+                                    }
+                                }
+                                cssMoveLastDxWorld += dx / zui.scale
+                                cssMoveLastDyWorld += dy / zui.scale
+                                cssMoveNode!.style.transform = `translate(${
+                                    cssMoveBaseX + cssMoveLastDxWorld
+                                }px, ${cssMoveBaseY + cssMoveLastDyWorld}px)`
+                                if (cssMoveChrome) {
+                                    cssMoveChrome.node.style.transform = `translate(${
+                                        cssMoveChrome.baseX + cssMoveLastDxWorld
+                                    }px, ${
+                                        cssMoveChrome.baseY + cssMoveLastDyWorld
+                                    }px)`
+                                }
+                                didCssMove = true
+                            } else {
+                                shape.position.x += dx / zui.scale
+                                shape.position.y += dy / zui.scale
+                                // Drag any connector tails/heads pinned to this
+                                // shape's ports along with it.
+                                reanchorArrowsForShape(shape)
+                            }
                         }
                     } else if (shape.elementData.isGroupSelector) {
                         // this blocks falls for the case when user has clicked and
@@ -3066,12 +3155,31 @@ function addZUI(
                         two.update()
                     }
                     mouse.set(e.clientX, e.clientY)
-                    two.update()
+                    // A CSS-transform move-drag repaints nothing in the scene, so
+                    // skip the full-scene render this frame — that's the whole win.
+                    if (!didCssMove) two.update()
                 }
         }
     }
 
     function mouseup(e: MouseEvent) {
+        // Commit a CSS-transform move-drag: write the accumulated delta into the
+        // element's real Two.js position, clear the live CSS transforms, then let
+        // the normal move/persist/history path below run (it reads the committed
+        // translation, sees the move, and persists + records it as usual).
+        if (cssMoveActive) {
+            const el = cssMoveEl
+            const finalX = cssMoveBaseX + cssMoveLastDxWorld
+            const finalY = cssMoveBaseY + cssMoveLastDyWorld
+            clearCssMove()
+            if (el) {
+                el.position.x = finalX
+                el.position.y = finalY
+                reanchorArrowsForShape(el)
+                selectionController.syncToTarget()
+                two.update()
+            }
+        }
         // Pan-mode (desktop): end the grab-drag, restore the grab cursor and
         // detach the on-demand listeners. Persist the viewport like the wheel.
         if (isMousePanning) {
@@ -3236,8 +3344,7 @@ function addZUI(
                     (drawOrigin.y + endCoords.y) / 2
                 )
 
-                const capturedPreview = previewShape
-                previewShape = null
+                drawPreviewActive = false
 
                 const finalId = generateUUID()
                 const finalShapeData = {
@@ -3261,10 +3368,9 @@ function addZUI(
                 // immediately — a visual cue to new users that the freshly drawn shape is editable.
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const finishPlacement = (el?: any) => {
-                    if (capturedPreview) {
-                        two.remove(capturedPreview)
-                        two.update()
-                    }
+                    // Keep the overlay up until the real element has rendered so
+                    // there's no blank flash, then drop it.
+                    removeDrawPreview()
                     if (el) selectionController.attach(el)
                 }
                 pollUntilElement(two, finalId, finishPlacement, {

--- a/src/newCanvas.tsx
+++ b/src/newCanvas.tsx
@@ -77,7 +77,13 @@ import {
     subscribeConnectorsEnabled,
     getDotGridEnabled,
     subscribeDotGridEnabled,
+    getViewportCullingEnabled,
 } from './utils/featureFlags'
+import {
+    cullToViewport,
+    uncullViewport,
+    CULLED_FLAG,
+} from './utils/viewportCulling'
 import {
     velocityToLinewidth,
     smoothLinewidth,
@@ -105,11 +111,13 @@ import {
     paintElementStroke,
 } from './utils/themeColorFlip'
 import { isSelectPanMode, isPanMode } from './utils/drawModeUtils'
+import { scheduleRender } from './utils/renderScheduler'
 import { createDiamondPath } from './factory/diamond'
 import { useCanvasClipboard } from './hooks/useCanvasClipboard'
 import type { HistoryEntry } from './hooks/useComponentHistory'
 import { exportSelectionAsSvg } from './utils/exportSelectionAsSvg'
 import CanvasContextMenu from './components/canvasContextMenu'
+import PerfOverlay from './components/dev/PerfOverlay'
 import {
     ElementRenderWrapper,
     GroupRenderWrapper,
@@ -121,6 +129,36 @@ import type {
     SelectedComponent,
     CurrentElement,
 } from './types/board'
+
+/**
+ * One lazy component per element *type*, not per element.
+ *
+ * `React.lazy()` returns a NEW component type on every call, and each one
+ * suspends and resolves independently — so calling it per element made a board
+ * of N elements resolve N Suspense boundaries in N separate commits, spreading
+ * the mount across hundreds of frames. Every one of those frames triggered a
+ * full O(scene) Two.js render (the SVG renderer walks every child on each
+ * update), which is O(frames × N) work.
+ *
+ * Keyed by componentType, the ~10 element modules resolve once and React can
+ * commit the elements in far fewer passes.
+ */
+const lazyElementCache = new Map<string, React.ComponentType<unknown>>()
+
+const getLazyElement = (
+    componentType: string,
+    moduleLoader: () => Promise<{
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        default: React.ComponentType<any>
+    }>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): React.ComponentType<any> => {
+    const cached = lazyElementCache.get(componentType)
+    if (cached) return cached
+    const lazy = React.lazy(moduleLoader)
+    lazyElementCache.set(componentType, lazy as React.ComponentType<unknown>)
+    return lazy
+}
 
 // A plain `line` shares the arrow's group structure (line + two endpoint
 // circles) and the entire arrow-draw / endpoint-edit machinery, so anywhere we
@@ -298,6 +336,33 @@ function addZUI(
     let lastTapTime = 0
     let lastTapX = 0
     let lastTapY = 0
+    // Wheel has no gesture-end event, so "is the user still zooming/scrolling"
+    // is tracked with a trailing timer. Used to suppress the hover hit-test
+    // mid-gesture, where its result is thrown away anyway.
+    let isWheeling = false
+    let wheelSettleTimer: number | null = null
+    // rAF gate for hoverDetectMove: pointers fire faster than we paint, and the
+    // hover scan is O(scene). At most one scan per frame.
+    let hoverFrame: number | null = null
+    let hoverPendingEvent: MouseEvent | null = null
+    // Viewport culling settle timer: cull runs on every camera change; once the
+    // gesture stops, unhide everything so the at-rest board is fully painted.
+    let cullSettleTimer: number | null = null
+
+    // Called from every camera handler (pan/zoom, mouse + touch) right before
+    // the batched render. Hides off-screen elements so the browser paints only
+    // the visible slice, then arms a timer to reveal them all once motion stops.
+    // A no-op (beyond the flag read) when culling is disabled.
+    function cullOnCameraChange(): void {
+        if (!getViewportCullingEnabled()) return
+        cullToViewport(two)
+        if (cullSettleTimer !== null) window.clearTimeout(cullSettleTimer)
+        cullSettleTimer = window.setTimeout(() => {
+            cullSettleTimer = null
+            uncullViewport(two)
+            scheduleRender(two)
+        }, 200)
+    }
     // Single-finger pan-mode state: when the toolbar pan button is active,
     // a one-finger touchstart begins panning the surface (instead of routing
     // to a synthetic mousedown). Cleared on touchend.
@@ -920,7 +985,9 @@ function addZUI(
     }
     const repaintForTheme = (): void => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        two.scene.children.forEach((child: any) => flipColorOnNodesAndStore(child))
+        two.scene.children.forEach((child: any) =>
+            flipColorOnNodesAndStore(child)
+        )
         // applyThemeStroke runs the single two.update() covering all changes.
         selectionController.applyThemeStroke()
     }
@@ -1376,7 +1443,25 @@ function addZUI(
     hoverCircle.noStroke()
     hoverCircle.opacity = 0
 
+    // Throttle the (O(scene)) hover scan to at most once per frame, and drop it
+    // entirely while a wheel gesture is in flight — the camera is moving under
+    // the cursor, so any hover result is stale before it paints. Only the most
+    // recent event of the frame is scanned; the earlier ones are superseded.
     function hoverDetectMove(e: MouseEvent) {
+        if (isWheeling) return
+
+        hoverPendingEvent = e
+        if (hoverFrame !== null) return
+
+        hoverFrame = requestAnimationFrame(() => {
+            hoverFrame = null
+            const pendingEvent = hoverPendingEvent
+            hoverPendingEvent = null
+            if (pendingEvent) runHoverDetect(pendingEvent)
+        })
+    }
+
+    function runHoverDetect(e: MouseEvent) {
         // No arrow-endpoint hover while panning or drawing/placing a geo object.
         if (
             isMousePanning ||
@@ -1388,7 +1473,7 @@ function addZUI(
         if (!isSelectPanMode(isPencilModeRef.current)) {
             if (lastHoveredCircleGroup) {
                 hoverCircle.opacity = 0
-                two.update()
+                scheduleRender(two)
                 lastHoveredCircleGroup = null
             }
             return
@@ -1424,13 +1509,19 @@ function addZUI(
         }
 
         if (found) {
+            // The indicator snaps to the endpoint, not the cursor, so while the
+            // pointer wanders within the hover threshold of the same endpoint
+            // nothing actually moves. Only render when something changed.
+            const moved =
+                hoverCircle.translation.x !== foundWx ||
+                hoverCircle.translation.y !== foundWy
             hoverCircle.translation.x = foundWx
             hoverCircle.translation.y = foundWy
             if (found !== lastHoveredCircleGroup) hoverCircle.opacity = 1
-            two.update()
+            if (moved || found !== lastHoveredCircleGroup) scheduleRender(two)
         } else if (lastHoveredCircleGroup) {
             hoverCircle.opacity = 0
-            two.update()
+            scheduleRender(two)
         }
         lastHoveredCircleGroup = found ?? null
     }
@@ -1731,7 +1822,11 @@ function addZUI(
             const line = child.children?.[0]
             if (!line) return
             if (ed.tailShapeId === shapeId && ed.tailEdge) {
-                const p = getShapePortPoint(group, ed.tailEdge, portGapSurface())
+                const p = getShapePortPoint(
+                    group,
+                    ed.tailEdge,
+                    portGapSurface()
+                )
                 if (ed.tailPortIndex > 0) {
                     // Keep the fan offset (direction follows the bound head).
                     applyStackedEndpoint(
@@ -1755,7 +1850,11 @@ function addZUI(
                 }
             }
             if (ed.headShapeId === shapeId && ed.headEdge) {
-                const p = getShapePortPoint(group, ed.headEdge, portGapSurface())
+                const p = getShapePortPoint(
+                    group,
+                    ed.headEdge,
+                    portGapSurface()
+                )
                 if (ed.headPortIndex > 0) {
                     // Keep the fan offset (direction follows the bound tail).
                     applyStackedEndpoint(
@@ -1852,7 +1951,11 @@ function addZUI(
         // Far endpoint vertex index for ordering: a tail bound here is ordered
         // by its head (vertex[1]); a head bound here by its tail (vertex[0]).
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const pushEntry = (child: any, line: any, endpoint: 'tail' | 'head') => {
+        const pushEntry = (
+            child: any,
+            line: any,
+            endpoint: 'tail' | 'head'
+        ) => {
             const farIdx = endpoint === 'tail' ? 1 : 0
             const coord = sideEdge
                 ? child.position.y + line.vertices[farIdx].y
@@ -2581,7 +2684,12 @@ function addZUI(
             mousePanLastY = e.clientY
             if (dx !== 0 || dy !== 0) {
                 zui.translateSurface(dx, dy)
-                two.update()
+                cullOnCameraChange()
+                // Batched, NOT a direct two.update(): pointers fire well above
+                // the paint rate (120Hz+ trackpads), so a synchronous render
+                // here means 2x the full O(scene) renders the display can even
+                // show. scheduleRender coalesces the burst into one per frame.
+                scheduleRender(two)
                 syncBackgroundToCamera()
                 onCameraChangeRef?.current?.({
                     scale: two.scene.scale,
@@ -3061,10 +3169,7 @@ function addZUI(
                 }
                 const drawnEd = arrowDrawElement?.elementData
                 if (drawnEd?.headShapeId && drawnEd?.headEdge) {
-                    restackPortConnectors(
-                        drawnEd.headShapeId,
-                        drawnEd.headEdge
-                    )
+                    restackPortConnectors(drawnEd.headShapeId, drawnEd.headEdge)
                 }
                 arrowDrawTailShapeId = null
                 arrowDrawTailPort = null
@@ -3630,7 +3735,20 @@ function addZUI(
             zui.translateSurface(-e.deltaX, -e.deltaY)
         }
 
-        two.update()
+        // A wheel gesture is in flight — suppress the hover hit-test until it
+        // settles (see hoverDetectMove). Wheel has no gesture-end event, so the
+        // flag is cleared on a short trailing timer.
+        isWheeling = true
+        if (wheelSettleTimer !== null) window.clearTimeout(wheelSettleTimer)
+        wheelSettleTimer = window.setTimeout(() => {
+            isWheeling = false
+            wheelSettleTimer = null
+        }, 120)
+
+        cullOnCameraChange()
+        // Batched — same reason as the pan handler: wheel/trackpad events fire
+        // faster than the display paints.
+        scheduleRender(two)
         syncBackgroundToCamera()
 
         onCameraChangeRef?.current?.({
@@ -3760,7 +3878,9 @@ function addZUI(
                 panLastY = lastTouch.clientY
                 if (dx !== 0 || dy !== 0) {
                     zui.translateSurface(dx, dy)
-                    two.update()
+                    cullOnCameraChange()
+                    // Batched — touchmove also outruns the paint rate.
+                    scheduleRender(two)
                     syncBackgroundToCamera()
                     onCameraChangeRef?.current?.({
                         scale: two.scene.scale,
@@ -3964,7 +4084,9 @@ function addZUI(
         twoFingerMidY = newMidY
         distance = newDist
 
-        two.update()
+        cullOnCameraChange()
+        // Batched — pinchmove fires per touch sample, not per frame.
+        scheduleRender(two)
         syncBackgroundToCamera()
 
         onCameraChangeRef?.current?.({
@@ -3979,9 +4101,12 @@ function addZUI(
     // elements actually are regardless of the live camera. Returns null when
     // there's nothing measurable yet. Shared by fitToContent and the load poll's
     // settle check (bounds stabilise once the element components apply x/y).
-    const computeContentSurfaceBounds = ():
-        | { left: number; top: number; right: number; bottom: number }
-        | null => {
+    const computeContentSurfaceBounds = (): {
+        left: number
+        top: number
+        right: number
+        bottom: number
+    } | null => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const children = two.scene.children as any[]
         let left = Infinity
@@ -3997,7 +4122,10 @@ function addZUI(
             // transient dummy/preview elements (the drag preview, the
             // lastAddedElement stand-in) that can sit at the origin or cursor,
             // far from the real content.
-            if (child.visible === false) continue
+            // A viewport-culled element is hidden for paint only — it's still
+            // real content, so measure it (its world bbox is valid regardless
+            // of visibility). Only skip genuinely-hidden groups.
+            if (child.visible === false && child[CULLED_FLAG] !== true) continue
             if (child.elementData.isDummy === true) continue
             let rect
             try {
@@ -4059,10 +4187,13 @@ function addZUI(
                 }
                 if (!rect) continue
                 const { left, top, right, bottom } = rect
-                if (![left, top, right, bottom].every((n) => Number.isFinite(n)))
+                if (
+                    ![left, top, right, bottom].every((n) => Number.isFinite(n))
+                )
                     continue
                 // Any overlap between the element rect and the viewport.
-                if (right > 0 && bottom > 0 && left < vw && top < vh) return true
+                if (right > 0 && bottom > 0 && left < vw && top < vh)
+                    return true
             }
             return false
         },
@@ -4261,6 +4392,15 @@ const Canvas: React.FC<CanvasProps> = (props) => {
             createTextAtSurfaceRef,
             onCameraChangeRef
         )
+
+        // Dev-only handles for profiling the camera from the console or a
+        // headless perf harness (drive the zoom/pan without synthesising input).
+        if (import.meta.env.DEV) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(window as any).__cbZui = zui_instance.zui
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(window as any).__cbTwo = two
+        }
 
         setZuiInstance(zui_instance)
         setTwoJSInstance(two)
@@ -4483,6 +4623,14 @@ const Canvas: React.FC<CanvasProps> = (props) => {
         const rank = new Map<unknown, number>()
         desired.forEach((c, i) => rank.set(c, i))
 
+        // Already in the desired order? Then there is nothing to restack, and
+        // re-rendering would be pure waste. This matters because the reconcile
+        // POLL re-runs this every frame while a board mounts: each render is
+        // O(scene) in the SVG renderer, so unconditionally rendering here cost
+        // ~90 full-scene renders per store change on a large board.
+        const alreadyOrdered = children.every((c, i) => desired[i] === c)
+        if (alreadyOrdered) return
+
         // Collection.sort fires the 'order' event that flags the SVG renderer
         // to physically reorder the <g> nodes — a bare splice would NOT.
         children.sort((a, b) => (rank.get(a) ?? 0) - (rank.get(b) ?? 0))
@@ -4622,12 +4770,14 @@ const Canvas: React.FC<CanvasProps> = (props) => {
                 const tryFit = (): void => {
                     initialFitPollRef.current = null
                     const sig = zuiInstance.contentBoundsSignature?.() ?? ''
-                    stableFrames = sig !== '' && sig === lastSig
-                        ? stableFrames + 1
-                        : 0
+                    stableFrames =
+                        sig !== '' && sig === lastSig ? stableFrames + 1 : 0
                     lastSig = sig
                     frame += 1
-                    if ((sig !== '' && stableFrames >= 3) || frame >= MAX_FRAMES) {
+                    if (
+                        (sig !== '' && stableFrames >= 3) ||
+                        frame >= MAX_FRAMES
+                    ) {
                         if (sig !== '') {
                             // Ensure the SVG (and each group's worldMatrix) is
                             // rendered at the settled positions before the
@@ -5117,6 +5267,9 @@ const Canvas: React.FC<CanvasProps> = (props) => {
         currentComponents: ComponentRecord[]
     ) => {
         let arr = [...prevElementsRef.current]
+        // Membership set over `arr`: this runs for every record on every store
+        // change, so a linear Array.includes() per item made it O(n²).
+        const seen = new Set(arr)
         let components = [...componentsToRenderRef.current]
         if (currentComponents && twoJSInstance) {
             // console.log(
@@ -5143,14 +5296,13 @@ const Canvas: React.FC<CanvasProps> = (props) => {
                     return
                 }
 
-                if (prevElementsRef.current.includes(item.id)) {
-                    // do nothing
-                    // console.log(
-                    //     'newCanvas ... Canvas ... handleSetComponentsToRender ... condition(currentComponents && twoJSInstance) === true ... condition(prevElements.includes(item.id)) === true'
-                    // )
+                if (seen.has(item.id)) {
+                    // do nothing — wrapper already exists
                 } else {
                     arr.push(item.id)
-                    const ElementToRender = React.lazy(
+                    seen.add(item.id)
+                    const ElementToRender = getLazyElement(
+                        item.componentType,
                         moduleLoader as () => Promise<{
                             // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             default: React.ComponentType<any>
@@ -5262,6 +5414,7 @@ const Canvas: React.FC<CanvasProps> = (props) => {
 
     return (
         <>
+            {import.meta.env.DEV && <PerfOverlay />}
             <div id="selector-rect"></div>
             {props.renderBackground?.()}
             <div id="main-two-root"></div>

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -176,6 +176,8 @@ export interface BoardContextValue {
     onCreateBoard: () => void
     createBoardLoading: boolean
     clearBoard: () => void
+    /** Open the file picker → parse → new-vs-merge chooser flow (P0 import). */
+    beginBoardImport: () => void
 
     // Two.js handles
     twoJSInstance: Two | null

--- a/src/utils/boardSizeGuard.ts
+++ b/src/utils/boardSizeGuard.ts
@@ -1,0 +1,139 @@
+import type { ComponentStore } from '../types/board'
+import { GROUP_COMPONENT, DRAFT_STORAGE_KEY } from '../constants/misc'
+import { isWelcomeComponent } from './welcomeSketch'
+
+/**
+ * localStorage stores strings as UTF-16 (~2 bytes/char) and the per-origin
+ * quota is ~5MB in most browsers. This budget is the write-side / load-side
+ * ceiling (in UTF-16 bytes) — a proactive line kept near, but under, the real
+ * quota so editing stays smooth and huge boards don't freeze on load.
+ *
+ * NOTE: this is a *storage footprint* (≈2× the on-disk file size), not the
+ * file size. A 2.3MB `.json` export occupies ~4.6MB here.
+ *
+ * For the import gate we don't rely on this estimate at all — see
+ * `draftFitsForStore`, which probes the browser's real quota. Tunable.
+ */
+export const MAX_DRAFT_BYTES = 5 * 1024 * 1024 // 5MB UTF-16 ≈ 2.5M JSON chars
+
+/**
+ * Write-side soft cap on the persisted draft, in REAL UTF-8 bytes (what
+ * `TextEncoder` and the on-disk export file measure — not the UTF-16 storage
+ * footprint). This is the number shown in the live readout.
+ *
+ * Keep it below the browser's real capacity so the guard reverts *before*
+ * localStorage throws. Browsers vary (~2.5–4 MB of UTF-8 JSON before the
+ * UTF-16 quota bites), so watch the live readout and tune this to your target.
+ */
+export const MAX_DRAFT_UTF8_BYTES = 3 * 1024 * 1024 // 3 MB UTF-8
+
+/**
+ * True UTF-8 byte size of the persisted draft as it sits in localStorage,
+ * via TextEncoder. Matches the export file size, not the UTF-16 footprint.
+ * Returns 0 when there is no draft.
+ */
+export function measureStoredDraftUtf8Bytes(): number {
+    let raw: string | null = null
+    try {
+        raw = localStorage.getItem(DRAFT_STORAGE_KEY)
+    } catch {
+        raw = null
+    }
+    return raw ? new TextEncoder().encode(raw).length : 0
+}
+
+/**
+ * The exact subset the draft actually persists — drops transient `groupobject`
+ * records and onboarding welcome-sketch seeds. Mirrors the filter in
+ * `useLocalDraftPersistence.writeDraft` so the measured size matches what
+ * really gets written.
+ */
+export function selectPersistableComponents(
+    store: ComponentStore
+): ComponentStore {
+    return Object.fromEntries(
+        Object.entries(store).filter(
+            ([, v]) =>
+                v?.componentType !== GROUP_COMPONENT && !isWelcomeComponent(v)
+        )
+    ) as ComponentStore
+}
+
+/** Approximate the localStorage footprint (UTF-16 bytes) of a serialized string. */
+export function measureBytes(serialized: string): number {
+    return serialized.length * 2
+}
+
+/**
+ * Test whether a store would actually fit in THIS browser's localStorage —
+ * by probing the real quota, not an estimate. Since an import replaces the
+ * current draft, we temporarily free the draft key, attempt to write the
+ * projected draft to a scratch key, and always restore the original in
+ * `finally`. Returns true if it fits.
+ */
+export function draftFitsForStore(store: ComponentStore): boolean {
+    const persistable = selectPersistableComponents(store)
+    if (Object.keys(persistable).length === 0) return true
+    // Approximate the real save envelope; components dominate the size.
+    const serialized = JSON.stringify({ components: persistable })
+
+    const PROBE_KEY = '__craftbase_fit_probe__'
+    let current: string | null = null
+    try {
+        current = localStorage.getItem(DRAFT_STORAGE_KEY)
+    } catch {
+        current = null
+    }
+    try {
+        if (current != null) localStorage.removeItem(DRAFT_STORAGE_KEY)
+        localStorage.setItem(PROBE_KEY, serialized)
+        return true
+    } catch {
+        return false
+    } finally {
+        try {
+            localStorage.removeItem(PROBE_KEY)
+        } catch {
+            /* ignore */
+        }
+        if (current != null) {
+            try {
+                localStorage.setItem(DRAFT_STORAGE_KEY, current)
+            } catch {
+                /* ignore — nothing we can do, original was already read */
+            }
+        }
+    }
+}
+
+/** Read the raw persisted draft string without parsing/rendering it. */
+export function readRawDraft(): string | null {
+    try {
+        return localStorage.getItem(DRAFT_STORAGE_KEY)
+    } catch {
+        return null
+    }
+}
+
+/** True when an already-persisted draft is too large to safely render. */
+export function isRawDraftOverBudget(raw: string): boolean {
+    return measureBytes(raw) > MAX_DRAFT_BYTES
+}
+
+/**
+ * Download the raw persisted draft as a file WITHOUT rendering it — the rescue
+ * path for a board too large to open. Reads straight from localStorage so it
+ * never mounts thousands of elements into Two.js (which is what freezes the
+ * page in the first place).
+ */
+export function downloadRawDraftBackup(raw: string): void {
+    const blob = new Blob([raw], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `craftbase-board-backup-${Date.now()}.json`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+}

--- a/src/utils/drawPreviewOverlay.ts
+++ b/src/utils/drawPreviewOverlay.ts
@@ -1,0 +1,115 @@
+// Screen-space DOM overlay for the shape-creation drag preview.
+//
+// Why this exists: while you drag out a new rectangle/circle/diamond, the old
+// path added the preview as a child of the Two.js scene and called
+// `two.update()` every mousemove. That repaints the SVG region under the
+// growing preview — and at low zoom the preview covers most of a dense board,
+// so the browser re-rasterises thousands of nested SVG nodes per frame (3-5fps
+// at 10% zoom). The scene itself isn't changing during the drag, only the
+// preview is, so there's no reason to touch the scene SVG at all.
+//
+// Instead we draw the preview as a single absolutely-positioned DOM element on
+// its own layer. Updating it is O(1) CSS and never dirties the scene SVG, so
+// the create-drag stays 60fps regardless of zoom or element count. The real
+// Two.js shape is still materialised on mouseup (unchanged) — this is purely
+// the transient drag visual.
+
+export type DrawPreviewKind = 'rectangle' | 'circle' | 'diamond'
+
+interface DrawPreviewStyle {
+    fill?: string
+    stroke?: string
+    linewidth?: number
+    opacity?: number
+}
+
+const SVG_NS = 'http://www.w3.org/2000/svg'
+
+let overlayEl: HTMLDivElement | null = null
+
+// Create (or replace) the preview element and attach it to <body>. Positioned
+// in viewport (client) coordinates, so callers pass raw clientX/clientY — no
+// world<->screen conversion, no dependence on the canvas element's offset.
+export function createDrawPreview(
+    kind: DrawPreviewKind,
+    style: DrawPreviewStyle
+): void {
+    removeDrawPreview()
+
+    const el = document.createElement('div')
+    const s = el.style
+    s.position = 'fixed'
+    s.left = '0px'
+    s.top = '0px'
+    s.width = '0px'
+    s.height = '0px'
+    s.pointerEvents = 'none'
+    s.zIndex = '50'
+    s.boxSizing = 'border-box'
+    s.opacity = String(style.opacity ?? 0.6)
+    s.willChange = 'left, top, width, height'
+
+    const stroke = style.stroke || '#000'
+    const fill = style.fill || '#fff'
+    const lw = style.linewidth || 1
+
+    if (kind === 'circle') {
+        s.background = fill
+        s.borderRadius = '50%'
+        s.border = `${lw}px solid ${stroke}`
+    } else if (kind === 'diamond') {
+        // A CSS border can't follow a clip-path edge, so a clip-path-only
+        // diamond has no visible outline — with a light fill it's invisible
+        // mid-drag. Render an inline SVG polygon instead so it carries a real
+        // stroke. viewBox + preserveAspectRatio:none stretches the unit diamond
+        // to the div; non-scaling-stroke keeps the outline a constant px width.
+        const svg = document.createElementNS(SVG_NS, 'svg')
+        svg.setAttribute('width', '100%')
+        svg.setAttribute('height', '100%')
+        svg.setAttribute('viewBox', '0 0 100 100')
+        svg.setAttribute('preserveAspectRatio', 'none')
+        svg.style.display = 'block'
+        svg.style.overflow = 'visible'
+        const poly = document.createElementNS(SVG_NS, 'polygon')
+        poly.setAttribute('points', '50,1 99,50 50,99 1,50')
+        poly.setAttribute('fill', fill)
+        poly.setAttribute('stroke', stroke)
+        poly.setAttribute('stroke-width', String(lw))
+        poly.setAttribute('vector-effect', 'non-scaling-stroke')
+        svg.appendChild(poly)
+        el.appendChild(svg)
+    } else {
+        s.background = fill
+        s.borderRadius = '3px'
+        s.border = `${lw}px solid ${stroke}`
+    }
+
+    document.body.appendChild(el)
+    overlayEl = el
+}
+
+// Position/size the preview from the drag's two corners, in client coords.
+export function updateDrawPreview(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number
+): void {
+    if (!overlayEl) return
+    const s = overlayEl.style
+    s.left = `${Math.min(x0, x1)}px`
+    s.top = `${Math.min(y0, y1)}px`
+    s.width = `${Math.abs(x1 - x0)}px`
+    s.height = `${Math.abs(y1 - y0)}px`
+}
+
+export function removeDrawPreview(): void {
+    if (overlayEl) {
+        overlayEl.remove()
+        overlayEl = null
+    }
+}
+
+export function hasDrawPreview(): boolean {
+    return overlayEl !== null
+}

--- a/src/utils/exportBoard.ts
+++ b/src/utils/exportBoard.ts
@@ -1,0 +1,53 @@
+import type { ComponentStore } from '../types/board'
+import { GROUP_COMPONENT } from '../constants/misc'
+import { isWelcomeComponent } from './welcomeSketch'
+import { version as appVersion } from '../../package.json'
+
+interface BoardViewport {
+    scale: number
+    tx: number
+    ty: number
+}
+
+/**
+ * Serialize the current board to a versioned, branded JSON envelope and
+ * trigger a browser download. Reuses the same canonical `ComponentStore`
+ * the localStorage draft persists, so round-trip fidelity is inherited.
+ */
+export function exportBoardAsJson(
+    componentStore: ComponentStore,
+    viewport: BoardViewport
+): void {
+    // Same save-side filter as useLocalDraftPersistence.ts — drop transient
+    // groups and onboarding welcome-sketch seeds so they never leave the app.
+    const components = Object.fromEntries(
+        Object.entries(componentStore).filter(
+            ([, v]) =>
+                v?.componentType !== GROUP_COMPONENT &&
+                !isWelcomeComponent(v)
+        )
+    ) as ComponentStore
+
+    const payload = {
+        formatVersion: '1.0',
+        app: 'craftbase',
+        appVersion,
+        exportedAt: Date.now(),
+        viewport,
+        components,
+    }
+    downloadJson(JSON.stringify(payload, null, 2))
+}
+
+/** Trigger a browser download of the JSON payload as a .json file. */
+function downloadJson(json: string): void {
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `craftbase-board-${Date.now()}.json`
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+}

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,6 +1,7 @@
 import {
     CONNECTORS_ENABLED_KEY,
     DOT_GRID_ENABLED_KEY,
+    DRAG_SCANS_ENABLED_KEY,
     VIEWPORT_CULLING_ENABLED_KEY,
 } from '../constants/misc'
 
@@ -88,6 +89,48 @@ export function subscribeDotGridEnabled(fn: Listener): () => void {
     dotGridListeners.add(fn)
     return (): void => {
         dotGridListeners.delete(fn)
+    }
+}
+
+// ── Drag-scan flag (perf testing) ─────────────────────────────────────────
+// Same runtime/localStorage model. Gates the O(N) scene scans that ride along
+// with dragging: `reanchorArrowsForShape` (per-frame, legacy move path),
+// `shapeHasBoundArrows` (once per drag, CSS fast-path eligibility) and the
+// hover-detect endpoint scan (per rAF). Turn OFF to measure drag/paint cost
+// with the scans removed on dense boards. Connector gluing and endpoint hover
+// stop working while off — this is a measurement lever, not a user feature.
+
+// Default ON: normal behavior. Disable only for perf isolation runs.
+const DEFAULT_DRAG_SCANS_ENABLED = true
+
+let dragScansCached: boolean | null = null
+const dragScansListeners = new Set<Listener>()
+
+export function getDragScansEnabled(): boolean {
+    if (dragScansCached === null) {
+        const stored = localStorage.getItem(DRAG_SCANS_ENABLED_KEY)
+        dragScansCached =
+            stored === null ? DEFAULT_DRAG_SCANS_ENABLED : stored === 'true'
+    }
+    return dragScansCached
+}
+
+export function setDragScansEnabled(enabled: boolean): void {
+    dragScansCached = enabled
+    try {
+        localStorage.setItem(DRAG_SCANS_ENABLED_KEY, String(enabled))
+    } catch {
+        // Persistence is best-effort; an in-memory toggle still works for the
+        // current session even if storage is full/blocked.
+    }
+    dragScansListeners.forEach((fn) => fn(enabled))
+}
+
+// Subscribe to live changes. Returns an unsubscribe fn.
+export function subscribeDragScansEnabled(fn: Listener): () => void {
+    dragScansListeners.add(fn)
+    return (): void => {
+        dragScansListeners.delete(fn)
     }
 }
 

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -25,7 +25,8 @@ const listeners = new Set<Listener>()
 export function getConnectorsEnabled(): boolean {
     if (cached === null) {
         const stored = localStorage.getItem(CONNECTORS_ENABLED_KEY)
-        cached = stored === null ? DEFAULT_CONNECTORS_ENABLED : stored === 'true'
+        cached =
+            stored === null ? DEFAULT_CONNECTORS_ENABLED : stored === 'true'
     }
     return cached
 }
@@ -96,7 +97,7 @@ export function subscribeDotGridEnabled(fn: Listener): () => void {
 // The hot camera handlers read `getViewportCullingEnabled()` cheaply per frame.
 
 // Opt-in feature: default OFF while it's validated on real boards.
-const DEFAULT_VIEWPORT_CULLING_ENABLED = false
+const DEFAULT_VIEWPORT_CULLING_ENABLED = true
 
 let cullingCached: boolean | null = null
 const cullingListeners = new Set<Listener>()

--- a/src/utils/featureFlags.ts
+++ b/src/utils/featureFlags.ts
@@ -1,6 +1,7 @@
 import {
     CONNECTORS_ENABLED_KEY,
     DOT_GRID_ENABLED_KEY,
+    VIEWPORT_CULLING_ENABLED_KEY,
 } from '../constants/misc'
 
 // Live, user-toggleable feature flags backed by localStorage.
@@ -86,5 +87,46 @@ export function subscribeDotGridEnabled(fn: Listener): () => void {
     dotGridListeners.add(fn)
     return (): void => {
         dotGridListeners.delete(fn)
+    }
+}
+
+// ── Viewport culling flag ─────────────────────────────────────────────────
+// Same runtime/localStorage model. Gates the paint-cost optimisation that hides
+// off-screen scene elements during pan/zoom (see `src/utils/viewportCulling.ts`).
+// The hot camera handlers read `getViewportCullingEnabled()` cheaply per frame.
+
+// Opt-in feature: default OFF while it's validated on real boards.
+const DEFAULT_VIEWPORT_CULLING_ENABLED = false
+
+let cullingCached: boolean | null = null
+const cullingListeners = new Set<Listener>()
+
+export function getViewportCullingEnabled(): boolean {
+    if (cullingCached === null) {
+        const stored = localStorage.getItem(VIEWPORT_CULLING_ENABLED_KEY)
+        cullingCached =
+            stored === null
+                ? DEFAULT_VIEWPORT_CULLING_ENABLED
+                : stored === 'true'
+    }
+    return cullingCached
+}
+
+export function setViewportCullingEnabled(enabled: boolean): void {
+    cullingCached = enabled
+    try {
+        localStorage.setItem(VIEWPORT_CULLING_ENABLED_KEY, String(enabled))
+    } catch {
+        // Persistence is best-effort; an in-memory toggle still works for the
+        // current session even if storage is full/blocked.
+    }
+    cullingListeners.forEach((fn) => fn(enabled))
+}
+
+// Subscribe to live changes. Returns an unsubscribe fn.
+export function subscribeViewportCullingEnabled(fn: Listener): () => void {
+    cullingListeners.add(fn)
+    return (): void => {
+        cullingListeners.delete(fn)
     }
 }

--- a/src/utils/handleScale.ts
+++ b/src/utils/handleScale.ts
@@ -10,6 +10,8 @@
 // per-handle drag listeners).
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { scheduleRender } from './renderScheduler'
+
 type ShapeLike = any
 
 // Set each handle's uniform scale to cancel the current camera zoom.
@@ -40,9 +42,12 @@ export function attachStrokeCounterScale(
         if (!Number.isFinite(scale) || scale <= 0) return
         apply(basePx / scale)
     }
-    // Seed once (mount-time, off the hot path) — this single update is fine.
+    // Seed once at mount. Batched, NOT a direct two.update(): every line/arrow
+    // seeds on mount, so a synchronous render here is one full O(scene) render
+    // per element — O(N²) across a board load. scheduleRender coalesces them
+    // all into a single render for the frame.
     set(initialScale || 1)
-    two.update()
+    scheduleRender(two)
     // On zoom, ONLY mutate — never call two.update() here. The camera's wheel
     // handler dispatches `zoomChanged` synchronously and then calls two.update()
     // exactly once, which paints every listener's mutation in a single render.
@@ -68,9 +73,10 @@ export function attachHandleCounterScale(
     two: ShapeLike,
     initialScale: number
 ): () => void {
-    // Seed once (mount-time, off the hot path) — this single update is fine.
+    // Seed once at mount — batched for the same reason as above: one sync render
+    // per mounting element is O(N²) across a board load.
     applyHandleCounterScale(handles, initialScale || 1)
-    two.update()
+    scheduleRender(two)
     // On zoom, ONLY mutate — never call two.update() here. The camera's wheel
     // handler calls two.update() once after dispatching `zoomChanged`, painting
     // every listener's mutation in a single render. A per-listener update would

--- a/src/utils/importBoard.ts
+++ b/src/utils/importBoard.ts
@@ -1,0 +1,100 @@
+import type { ComponentRecord, ComponentStore } from '../types/board'
+import { GROUP_COMPONENT } from '../constants/misc'
+
+export interface BoardViewport {
+    scale: number
+    tx: number
+    ty: number
+}
+
+export interface ParsedImport {
+    /** Only the records that passed validation. */
+    components: ComponentStore
+    /** Restored on "Open as new canvas"; null when the file carried none. */
+    viewport: BoardViewport | null
+    /** Total records seen in the file (valid + skipped). */
+    total: number
+    /** Records dropped for being malformed / unknown. */
+    skipped: number
+}
+
+/**
+ * Open a native file picker and resolve with the chosen file's text — or null
+ * if the user cancels. Accepts both the branded export (`.json`) and the raw
+ * draft backup the load-side rescue produces (same `components` shape).
+ */
+export function openBoardFilePicker(): Promise<string | null> {
+    return new Promise((resolve) => {
+        const input = document.createElement('input')
+        input.type = 'file'
+        input.accept = '.json,.craftbase,application/json'
+        input.onchange = (): void => {
+            const file = input.files?.[0]
+            if (!file) {
+                resolve(null)
+                return
+            }
+            file.text()
+                .then(resolve)
+                .catch(() => resolve(null))
+        }
+        input.click()
+    })
+}
+
+function isValidRecord(value: unknown): value is ComponentRecord {
+    if (!value || typeof value !== 'object') return false
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r = value as any
+    return (
+        typeof r.componentType === 'string' &&
+        r.componentType.length > 0 &&
+        r.componentType !== GROUP_COMPONENT &&
+        Number.isFinite(r.x) &&
+        Number.isFinite(r.y)
+    )
+}
+
+function isValidViewport(value: unknown): value is BoardViewport {
+    if (!value || typeof value !== 'object') return false
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = value as any
+    return (
+        Number.isFinite(v.scale) &&
+        Number.isFinite(v.tx) &&
+        Number.isFinite(v.ty)
+    )
+}
+
+/**
+ * Parse + validate an imported board file. Mirrors `persistBoard`'s defensive
+ * skip: records missing a `componentType` (or geometry) are dropped and
+ * counted rather than failing the whole import. Throws only when the file
+ * isn't valid JSON or has no `components` object at all.
+ */
+export function parseImportedBoard(text: string): ParsedImport {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const raw = JSON.parse(text) as any // throws on malformed JSON
+    const rawComponents = raw?.components
+    if (!rawComponents || typeof rawComponents !== 'object') {
+        throw new Error('File does not contain a board (no components).')
+    }
+
+    const entries = Object.entries(rawComponents as Record<string, unknown>)
+    const components: ComponentStore = {}
+    let skipped = 0
+    for (const [id, value] of entries) {
+        if (isValidRecord(value)) {
+            components[id] = value
+        } else {
+            skipped++
+        }
+    }
+
+    return {
+        components,
+        viewport: isValidViewport(raw?.viewport) ? raw.viewport : null,
+        total: entries.length,
+        skipped,
+    }
+}

--- a/src/utils/renderScheduler.ts
+++ b/src/utils/renderScheduler.ts
@@ -1,0 +1,103 @@
+/**
+ * Batched Two.js render scheduler.
+ *
+ * `two.update()` is O(scene size): the SVG renderer walks every child on each
+ * call. Element components each called it directly in their mount effects, so
+ * mounting N elements in one React commit cost N full-scene renders — O(N²) in
+ * a single synchronous task. At ~2.4k elements that's a ~10s block, which is
+ * exactly what trips Chrome's "Page Unresponsive" dialog.
+ *
+ * `scheduleRender` coalesces every caller in a frame into ONE `two.update()`,
+ * turning the mount storm back into O(N).
+ *
+ * Callers that need the rendered SVG node (the common
+ * `two.update(); document.getElementById(group.id)` pattern) pass an
+ * `afterRender` callback — it runs immediately after the single batched update,
+ * by which point the node exists.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Two = any
+
+interface PendingRender {
+    frame: number | null
+    callbacks: Array<() => void>
+}
+
+const pending = new WeakMap<Two, PendingRender>()
+
+/**
+ * Run `two.update()`, absorbing the scene.subtractions corruption documented in
+ * CLAUDE.md: if a render throws mid-teardown, the stale subtraction stays
+ * queued and every future update retries the broken removeChild forever.
+ */
+function safeUpdate(two: Two): void {
+    try {
+        two.update()
+    } catch (_) {
+        if (two?.scene) {
+            two.scene.subtractions.length = 0
+            two.scene._flagSubtractions = false
+        }
+    }
+}
+
+function runCallbacks(entry: PendingRender): void {
+    const callbacks = entry.callbacks
+    entry.callbacks = []
+    for (const cb of callbacks) {
+        try {
+            cb()
+        } catch (_) {
+            /* one bad callback must not sink the rest of the batch */
+        }
+    }
+}
+
+/**
+ * Request a render on the next animation frame. Any number of calls within the
+ * same frame collapse into a single `two.update()`.
+ *
+ * @param afterRender Optional callback run right after the batched update, when
+ *   the element's SVG node is guaranteed to exist in the DOM.
+ */
+export function scheduleRender(two: Two, afterRender?: () => void): void {
+    if (!two) return
+
+    let entry = pending.get(two)
+    if (!entry) {
+        entry = { frame: null, callbacks: [] }
+        pending.set(two, entry)
+    }
+    if (afterRender) entry.callbacks.push(afterRender)
+
+    if (entry.frame !== null) return
+
+    entry.frame = requestAnimationFrame(() => {
+        const current = pending.get(two)
+        if (!current) return
+        current.frame = null
+        safeUpdate(two)
+        runCallbacks(current)
+    })
+}
+
+/**
+ * Render synchronously right now, flushing any batch queued for this frame.
+ *
+ * Use only where the very next statement must read post-render geometry
+ * (getBoundingClientRect, worldMatrix). Interactive one-shot paths — a drag
+ * tick, a resize handle — are fine to keep synchronous: they render once per
+ * event, not once per element.
+ */
+export function flushRender(two: Two): void {
+    if (!two) return
+
+    const entry = pending.get(two)
+    if (entry?.frame !== null && entry !== undefined) {
+        cancelAnimationFrame(entry.frame as number)
+        entry.frame = null
+    }
+    safeUpdate(two)
+    if (entry) runCallbacks(entry)
+}

--- a/src/utils/viewportCulling.ts
+++ b/src/utils/viewportCulling.ts
@@ -1,0 +1,172 @@
+// Viewport culling — the lever against the pan/zoom PAINT cost on dense boards.
+//
+// Why it exists: craftbase elements are nested SVG groups (a shape is a <g> of
+// ~4–9 nodes: fill path + hit-area path + text layer + endpoint handles). A
+// 2000-element board is ~8600 SVG DOM nodes. Two.js's SVG renderer applies pan
+// as a transform on the scene root, and the browser must re-rasterise every
+// VISIBLE vector node each frame — so pan/zoom cost scales with how many
+// elements sit inside the viewport, not with total scene size. At 10% zoom the
+// whole board is on screen and every node repaints per frame; at 118% only a
+// handful do (which is exactly why panning feels smooth zoomed-in and janky
+// zoomed-out). Setting `visible = false` emits `display:none`, so the browser
+// skips painting that subtree entirely.
+//
+// Scope: cull only DURING active motion, then unhide once the gesture settles
+// (see `scheduleCullSettle`). At rest everything is visible, so export,
+// fit-to-content, hit-testing and selection never observe a hidden element —
+// which keeps this optimisation from colliding with any of those paths.
+
+import { GROUP_COMPONENT } from '../constants/misc'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Two = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SceneChild = any
+
+// Elements partially outside the viewport must NOT pop, so measure against a
+// viewport expanded by this many screen px on every side.
+const DEFAULT_MARGIN_PX = 300
+
+// Marks an element hidden by culling (vs. genuinely hidden by undo/group
+// bookkeeping), so `computeContentSurfaceBounds` still counts it as content.
+export const CULLED_FLAG = '__cbCulled'
+
+interface WorldBounds {
+    tx: number
+    ty: number
+    left: number
+    top: number
+    right: number
+    bottom: number
+}
+
+// Cache each element's world-space AABB, keyed by the object. World bounds are
+// camera-independent (they only change when the element itself moves/resizes),
+// so during a pan/zoom — where only the camera changes — every element is a
+// cache hit and the per-frame work is pure arithmetic, no getBoundingClientRect.
+const boundsCache = new WeakMap<SceneChild, WorldBounds>()
+
+function worldBounds(child: SceneChild): WorldBounds | null {
+    const cached = boundsCache.get(child)
+    const tx = child.translation.x
+    const ty = child.translation.y
+    // Reuse unless the element moved. Resizes that keep the same origin are rare
+    // and self-correct on the next move; a stale edge here only mis-culls an
+    // element by its own size, well within DEFAULT_MARGIN_PX.
+    if (cached && cached.tx === tx && cached.ty === ty) return cached
+
+    let rect
+    try {
+        // Shallow = surface/world coords, independent of the live camera
+        // (mirrors computeContentSurfaceBounds in newCanvas).
+        rect = child.getBoundingClientRect(true)
+    } catch {
+        return null
+    }
+    if (!rect) return null
+    const { left, top, right, bottom } = rect
+    if (![left, top, right, bottom].every((n) => Number.isFinite(n))) return null
+
+    const b: WorldBounds = { tx, ty, left, top, right, bottom }
+    boundsCache.set(child, b)
+    return b
+}
+
+function isCullable(child: SceneChild): boolean {
+    const data = child?.elementData
+    if (!data?.id) return false // selection chrome, welcome sketch, dummies
+    if (data.componentType === GROUP_COMPONENT) return false // visibility is managed
+    if (data.isDummy === true) return false
+    return true
+}
+
+export interface CullStats {
+    visible: number
+    culled: number
+    total: number
+}
+
+/**
+ * Hide every cullable element whose screen bounds fall outside the viewport,
+ * show the rest. Does NOT call two.update() — the caller batches the render
+ * (the camera handlers already do, via scheduleRender). Returns counts for the
+ * dev overlay.
+ */
+export function cullToViewport(
+    two: Two,
+    marginPx: number = DEFAULT_MARGIN_PX
+): CullStats {
+    const scene = two?.scene
+    if (!scene) return { visible: 0, culled: 0, total: 0 }
+
+    const scale = scene.scale || 1
+    const tx = scene.translation.x
+    const ty = scene.translation.y
+    const vw = window.innerWidth
+    const vh = window.innerHeight
+
+    let visible = 0
+    let culled = 0
+    let total = 0
+
+    for (const child of scene.children) {
+        if (!isCullable(child)) continue
+        total++
+
+        const wb = worldBounds(child)
+        if (!wb) {
+            // Unmeasurable — never hide it (fail safe = painted).
+            if (child.visible === false && child[CULLED_FLAG]) {
+                child.visible = true
+                child[CULLED_FLAG] = false
+            }
+            visible++
+            continue
+        }
+
+        // World AABB → screen AABB.
+        const sLeft = wb.left * scale + tx
+        const sRight = wb.right * scale + tx
+        const sTop = wb.top * scale + ty
+        const sBottom = wb.bottom * scale + ty
+
+        const onScreen =
+            sRight > -marginPx &&
+            sLeft < vw + marginPx &&
+            sBottom > -marginPx &&
+            sTop < vh + marginPx
+
+        if (onScreen) {
+            // Only un-hide elements WE hid — never override a genuine hide.
+            if (child.visible === false && child[CULLED_FLAG]) {
+                child.visible = true
+                child[CULLED_FLAG] = false
+            }
+            visible++
+        } else if (child.visible !== false) {
+            child.visible = false
+            child[CULLED_FLAG] = true
+            culled++
+        } else if (child[CULLED_FLAG]) {
+            culled++
+        }
+    }
+
+    return { visible, culled, total }
+}
+
+/**
+ * Undo culling: reveal every element we hid (leaving genuinely-hidden ones
+ * alone). Call when the gesture settles so at-rest state is fully painted.
+ * Does NOT render — caller batches.
+ */
+export function uncullViewport(two: Two): void {
+    const scene = two?.scene
+    if (!scene) return
+    for (const child of scene.children) {
+        if (child[CULLED_FLAG]) {
+            child.visible = true
+            child[CULLED_FLAG] = false
+        }
+    }
+}

--- a/src/views/Board/board.tsx
+++ b/src/views/Board/board.tsx
@@ -35,6 +35,18 @@ import OkIcon from '../../assets/ok.svg?react'
 import CloseIcon from '../../assets/close.svg?react'
 import PermissionErrorModal from '../../components/modals/PermissionErrorModal'
 import StorageLimitModal from '../../components/modals/StorageLimitModal'
+import {
+    BoardFullModal,
+    BoardTooLargeModal,
+} from '../../components/modals/BoardSizeLimitModal'
+import { exportBoardAsJson } from '../../utils/exportBoard'
+import ImportBoardModal from '../../components/modals/ImportBoardModal'
+import {
+    openBoardFilePicker,
+    parseImportedBoard,
+} from '../../utils/importBoard'
+import type { ParsedImport, BoardViewport } from '../../utils/importBoard'
+import { draftFitsForStore } from '../../utils/boardSizeGuard'
 import { generateUUID, generateRandomUsernames } from '../../utils/misc'
 import { prefetchElementModule } from '../../elementModules'
 import {
@@ -113,6 +125,13 @@ function stripTypename(obj: any): any {
         )
     }
     return obj
+}
+
+/** Human-readable size for the live local-draft readout (UTF-8 bytes). */
+const formatDraftBytes = (n: number): string => {
+    if (n < 1024) return `${n} B`
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`
+    return `${(n / (1024 * 1024)).toFixed(2)} MB`
 }
 
 const BoardViewPage: React.FC<BoardProps> = (props) => {
@@ -340,6 +359,8 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
     }, [setDefaultFill, setDefaultStrokeColor, setDefaultTextColor])
 
     const onStorageLimitRef = useRef<(() => Promise<void>) | null>(null)
+    // Write-side guard callback: assigned below once undoLastAction exists.
+    const onDraftOverBudgetRef = useRef<(() => void) | null>(null)
 
     const {
         showStorageLimitModal,
@@ -348,6 +369,11 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
         setStorageLimitBoardUrl,
         handleStartNewCanvas,
         handleContinueOnSavedBoard,
+        showBoardTooLargeModal,
+        handleDownloadBoardBackup,
+        handleStartFreshFromTooLarge,
+        handleOpenBoardAnyway,
+        draftSizeBytes,
     } = useLocalDraftPersistence({
         isPersisted,
         localBoardId,
@@ -356,6 +382,7 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
         backgroundBoardIdRef,
         setBackgroundBoardId,
         onStorageLimitRef,
+        onDraftOverBudgetRef,
         welcomeSketch: props.welcomeSketch,
         isMobile,
     })
@@ -387,6 +414,256 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
         selectedGroupRef,
         stripTypename,
     })
+
+    // Write-side size guard. The measurement lives in useLocalDraftPersistence
+    // (real UTF-8 size of the persisted draft, after each save); when it's over
+    // budget it calls this, and we revert the last action + open the "board is
+    // full" modal. Skip when there's nothing to revert (a draft hydration or
+    // "open anyway"), so the guard never fights a load it can't roll back.
+    const [showBoardFullModal, setShowBoardFullModal] = useState(false)
+    onDraftOverBudgetRef.current = (): void => {
+        if (historyLogRef.current.length === 0) return
+        undoLastAction()
+        setShowBoardFullModal(true)
+    }
+
+    // Export the current board to a .json file — the "keep working elsewhere"
+    // path offered by the board-full modal. Reads viewport off the live scene.
+    const handleExportBoardFromModal = useCallback(() => {
+        const scene = twoJSInstanceRef.current?.scene
+        const viewport = scene
+            ? {
+                  scale: typeof scene.scale === 'number' ? scene.scale : 1,
+                  tx: scene.translation.x,
+                  ty: scene.translation.y,
+              }
+            : { scale: 1, tx: 0, ty: 0 }
+        exportBoardAsJson(stateRefForComponentStore.current, viewport)
+        setShowBoardFullModal(false)
+    }, [])
+
+    // ---- Board import (P0) ----
+    // The chooser modal is driven by board state; the parsed file waits in a
+    // ref until the user picks "Open as new" vs "Merge".
+    const [showImportChooser, setShowImportChooser] = useState(false)
+    const [importError, setImportError] = useState<string | null>(null)
+    const pendingImportRef = useRef<ParsedImport | null>(null)
+
+    // Set the camera absolutely to a saved viewport: reset to identity, then
+    // zoom + translate (the fitToContent pattern in newCanvas). zoomSet keeps
+    // ZUI's internal scale in sync — never set two.scene.scale directly.
+    const restoreImportedViewport = useCallback((vp: BoardViewport): void => {
+        const zui = zuiInBoardRef.current?.zui
+        if (!zui) return
+        try {
+            zui.reset?.()
+            zui.zoomSet(vp.scale, 0, 0)
+            zui.translateSurface(vp.tx, vp.ty)
+            twoJSInstanceRef.current?.update()
+        } catch (e) {
+            console.error('[import] viewport restore failed', e)
+        }
+    }, [])
+
+    // Re-glue every docked connector whose bound shape is present in `store`.
+    // The listener in newCanvas polls for fresh mounts, so dispatching now
+    // (before the elements mount) is safe.
+    const restackBoundPortsForStore = useCallback(
+        (store: ComponentStore): void => {
+            const ports: { shapeId: string; edge: string }[] = []
+            Object.values(store).forEach((r) => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const rec = r as any
+                ;(['tail', 'head'] as const).forEach((end) => {
+                    const sid = rec[`${end}ShapeId`]
+                    const edge = rec[`${end}Edge`]
+                    if (
+                        typeof sid === 'string' &&
+                        store[sid] &&
+                        typeof edge === 'string'
+                    ) {
+                        ports.push({ shapeId: sid, edge })
+                    }
+                })
+            })
+            if (ports.length > 0) {
+                window.dispatchEvent(
+                    new CustomEvent('restackPorts', { detail: { ports } })
+                )
+            }
+        },
+        []
+    )
+
+    // Replace the whole canvas with the imported board and rotate the local
+    // board id. Mirrors clearBoard's teardown + persistBoard's id rotation.
+    const importAsNewCanvas = useCallback(
+        (parsed: ParsedImport): void => {
+            window.dispatchEvent(new Event('clearSelector'))
+            setSelectedComponent(null)
+            twoJSInstanceRef.current?.clear()
+            twoJSInstanceRef.current?.update()
+
+            const newLocalId = generateUUID()
+            const store: ComponentStore = {}
+            Object.entries(parsed.components).forEach(([id, comp]) => {
+                store[id] = { ...comp, boardId: newLocalId }
+            })
+            stateRefForComponentStore.current = store
+            // Rotate localBoardId without the id-change effect wiping the store.
+            skipComponentStoreResetRef.current = true
+            setLocalBoardId(newLocalId)
+            setComponentStore(store)
+            clearHistory(isPersisted)
+
+            if (parsed.viewport) restoreImportedViewport(parsed.viewport)
+            restackBoundPortsForStore(store)
+        },
+        [isPersisted, restoreImportedViewport, restackBoundPortsForStore]
+    )
+
+    // Merge the imported board into the current canvas: re-key every id to a
+    // fresh UUID (so it can't collide), remap in-file port bindings to the
+    // clones (drop bindings to shapes not in the file), and stack on top. One
+    // BATCH entry so a single undo removes the whole import.
+    const mergeImportedBoard = useCallback(
+        (parsed: ParsedImport): void => {
+            const records = Object.values(parsed.components)
+            // Add in ascending original z-order so the assigned positions
+            // preserve the imported set's relative stacking.
+            records.sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+
+            // Precompute the current top position ONCE. Passing explicit
+            // positions makes addToLocalComponentStore skip its per-add O(n)
+            // max-scan — otherwise a bulk merge is O(n²) and freezes.
+            const baseMax = Object.values(
+                stateRefForComponentStore.current
+            ).reduce((m: number, c) => {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const p = (c as any)?.position
+                return Number.isFinite(p) ? Math.max(m, p) : m
+            }, 0)
+
+            const idMap = new Map<string, string>()
+            records.forEach((r) => idMap.set(r.id, generateUUID()))
+
+            const batch: HistoryEntry[] = []
+            const ports: { shapeId: string; edge: string }[] = []
+            records.forEach((r, i) => {
+                const newId = idMap.get(r.id) as string
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const cloned: any = { ...r, id: newId, boardId }
+                // Explicit top position, in sorted order — O(1) per add.
+                cloned.position = baseMax + i + 1
+                ;(['tail', 'head'] as const).forEach((end) => {
+                    const boundId = cloned[`${end}ShapeId`]
+                    if (typeof boundId !== 'string') return
+                    const mapped = idMap.get(boundId)
+                    if (mapped) {
+                        cloned[`${end}ShapeId`] = mapped
+                        const edge = cloned[`${end}Edge`]
+                        if (typeof edge === 'string') {
+                            ports.push({ shapeId: mapped, edge })
+                        }
+                    } else {
+                        cloned[`${end}ShapeId`] = null
+                        cloned[`${end}Edge`] = null
+                        cloned[`${end}PortIndex`] = 0
+                    }
+                })
+                addToLocalComponentStore(
+                    newId,
+                    cloned.componentType,
+                    cloned,
+                    true
+                )
+                batch.push({
+                    action: 'ADD',
+                    id: newId,
+                    componentInfo: { ...cloned },
+                })
+            })
+            if (batch.length > 0) recordBatchToHistoryLog(batch)
+            if (ports.length > 0) {
+                window.dispatchEvent(
+                    new CustomEvent('restackPorts', { detail: { ports } })
+                )
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [boardId]
+    )
+
+    const beginBoardImport = useCallback(async (): Promise<void> => {
+        const text = await openBoardFilePicker()
+        if (text == null) return // cancelled
+        try {
+            const parsed = parseImportedBoard(text)
+            if (Object.keys(parsed.components).length === 0) {
+                pendingImportRef.current = null
+                setImportError('This file has no readable board elements.')
+            } else {
+                pendingImportRef.current = parsed
+                setImportError(null)
+            }
+        } catch (e) {
+            pendingImportRef.current = null
+            setImportError(
+                e instanceof Error ? e.message : 'Could not read this file.'
+            )
+        }
+        setShowImportChooser(true)
+    }, [])
+
+    // Reject an import that can't fit BEFORE applying it. Applying then letting
+    // the write-side guard revert a too-large import is what froze the page —
+    // so gate here (against the browser's REAL localStorage quota) and keep the
+    // modal in its error state instead.
+    const rejectIfWontFit = useCallback((projected: ComponentStore): boolean => {
+        if (draftFitsForStore(projected)) return false
+        setImportError(
+            "This board is too large to fit in this browser's local storage. " +
+                'Browsers store canvas text at roughly twice its file size and ' +
+                'cap local storage near 5 MB, so very large boards can’t be ' +
+                'saved locally. Try a smaller board, or split it across canvases.'
+        )
+        return true
+    }, [])
+
+    const handleImportOpenAsNew = useCallback(() => {
+        const parsed = pendingImportRef.current
+        if (!parsed) {
+            setShowImportChooser(false)
+            return
+        }
+        if (rejectIfWontFit(parsed.components)) return // stay open, show error
+        setShowImportChooser(false)
+        pendingImportRef.current = null
+        importAsNewCanvas(parsed)
+    }, [importAsNewCanvas, rejectIfWontFit])
+
+    const handleImportMerge = useCallback(() => {
+        const parsed = pendingImportRef.current
+        if (!parsed) {
+            setShowImportChooser(false)
+            return
+        }
+        // Project the merged result (current store + imported) and gate on it.
+        const projected: ComponentStore = {
+            ...stateRefForComponentStore.current,
+            ...parsed.components,
+        }
+        if (rejectIfWontFit(projected)) return // stay open, show error
+        setShowImportChooser(false)
+        pendingImportRef.current = null
+        mergeImportedBoard(parsed)
+    }, [mergeImportedBoard, rejectIfWontFit])
+
+    const handleImportChooserClose = useCallback(() => {
+        setShowImportChooser(false)
+        pendingImportRef.current = null
+        setImportError(null)
+    }, [])
 
     // Clear stale interaction flags from localStorage on mount so a page refresh
     // never triggers SCENARIO_DRAW_SHAPE / SCENARIO_ARROW_DRAW / etc. on the
@@ -1734,6 +2011,7 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
         undoLastAction,
         redoLastAction,
         clearBoard,
+        beginBoardImport,
     }
 
     return (
@@ -1852,6 +2130,40 @@ const BoardViewPage: React.FC<BoardProps> = (props) => {
                 onStartNew={handleStartNewCanvas}
                 onContinue={handleContinueOnSavedBoard}
             />
+            <BoardFullModal
+                open={showBoardFullModal}
+                onClose={() => setShowBoardFullModal(false)}
+                onExport={handleExportBoardFromModal}
+            />
+            <BoardTooLargeModal
+                open={showBoardTooLargeModal}
+                onDownloadBackup={handleDownloadBoardBackup}
+                onStartFresh={handleStartFreshFromTooLarge}
+                onOpenAnyway={handleOpenBoardAnyway}
+            />
+            <ImportBoardModal
+                open={showImportChooser}
+                onClose={handleImportChooserClose}
+                error={importError}
+                total={pendingImportRef.current?.total}
+                skipped={pendingImportRef.current?.skipped}
+                onOpenAsNew={handleImportOpenAsNew}
+                onMerge={handleImportMerge}
+            />
+            {!isPersisted && draftSizeBytes > 0 && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        bottom: 20,
+                        right: 12,
+                        zIndex: 10,
+                    }}
+                    className="text-xs text-ink-mid bg-card-bg border border-border-panel rounded px-2 py-1 select-none pointer-events-none"
+                    title="Local draft size (UTF-8)"
+                >
+                    Draft {formatDraftBytes(draftSizeBytes)}
+                </div>
+            )}
         </>
     )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,7 @@ module.exports = {
         fontFamily: {
             ui: ['Geist', 'system-ui', 'sans-serif'],
             display: ['Fraunces', 'Georgia', 'serif'],
-            sketch: ['Caveat', 'cursive'],
+            sketch: ['Caveat Brush', 'cursive'],
             mono: ['Geist Mono', 'monospace'], // added — for coordinates, hex values, dimension chips
         },
         // borderWidth: {


### PR DESCRIPTION
This PR addresses 
- Export and import option for craftbase board data. Now you can sync craftbase work to your local machine so that you don't lose it unexpectedly.
- Add viewport culling for performance reason. At 3000 elements in board, there was fps degradation while drag/pan process. This viewport culling ensures there is smooth experience in drag/pan even at 3000 elements or more.
- Add limit for craftbase board size. On board size can only have until 4MB. Beyond that you'll need to either remove elements or start fresh. It will give you option to backup the work you've done in form of JSON file to be downloaded.
